### PR TITLE
sif-baseimage, biblioteker i egne jar-filer for bedre støtte tviy og docker build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM amazoncorretto:21-alpine3.20
+FROM ghcr.io/navikt/sif-baseimages/java-21:2025.02.13.1522Z
+LABEL org.opencontainers.image.source=https://github.com/navikt/ung-deltakelse-opplyser
 
+COPY target/lib/*.jar lib/
 COPY target/*.jar app.jar
-
-CMD ["java", "-jar", "app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -247,8 +247,36 @@
         <testSourceDirectory>src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/target/lib/</outputDirectory>
+                            <includeScope>runtime</includeScope>
+                            <prependGroupId>true</prependGroupId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathLayoutType>custom</classpathLayoutType>
+                            <customClasspathLayout>lib/$${artifact.groupId}.$${artifact.artifactId}-$${artifact.version}$${dashClassifier?}.$${artifact.extension}</customClasspathLayout>
+                            <mainClass>no.nav.ung.deltakelseopplyser.UngDeltakelseOpplyserApplicationKt</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
### **Behov / Bakgrunn**

Ønskelig å bruke samme java-baseimage flest mulig steder for konsistens, minimere angrepsflate, og mindre nedlasting til verdikjede.

Ønskelig å ha biblioteker i separate jar-filer inne i image, da åpner muligheten for at trivy kan finne sårbarheter i avhengighetene.

### **Løsning**

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
