### PR TITLE
Kansellerer eksisterende uløst oppgave ved endring av startdato/sluttdato

### DIFF
--- a/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -59,9 +59,10 @@ class OppgaveDAO(
         return this
     }
 
-    fun markerSomKansellert() {
+    fun markerSomKansellert(): OppgaveDAO {
         this.status = OppgaveStatus.KANSELLERT
         this.løstDato = ZonedDateTime.now(ZoneOffset.UTC)
+        return this
     }
 }
 

--- a/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -223,8 +223,7 @@ class UngdomsprogramregisterService(
         eksisterende.oppgaver.find { it.oppgavetype == Oppgavetype.BEKREFT_ENDRET_STARTDATO && it.status == OppgaveStatus.ULØST }
             ?.apply {
                 logger.info("Fant uløst oppgave for endring av startdato. Markerer som kansellert.")
-                markerSomKansellert()
-                eksisterende.oppdaterOppgave(this)
+                eksisterende.oppdaterOppgave(markerSomKansellert())
                 deltakelseRepository.save(eksisterende)
             }
 
@@ -269,8 +268,7 @@ class UngdomsprogramregisterService(
         eksisterende.oppgaver.find { it.oppgavetype == Oppgavetype.BEKREFT_ENDRET_SLUTTDATO && it.status == OppgaveStatus.ULØST }
             ?.apply {
                 logger.info("Fant uløst oppgave for endring av sluttdato. Markerer som kansellert.")
-                markerSomKansellert()
-                eksisterende.oppdaterOppgave(this)
+                eksisterende.oppdaterOppgave(markerSomKansellert())
                 deltakelseRepository.save(eksisterende)
             }
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det er behov for å overstyre en endring på startdato/sluttdato. 
Pr. nå kan det ikke opprettes flere flere oppgavetyper av samme type med uløst status.

### **Løsning**
Dersom det eksisterer en uløst oppgave ved endring av startdato/sluttdato, vil den nå kanselleres, før det opprettes ny.

### **Andre endringer**
- Validerer perioden på deltakelsen slik at startdato ikke kan være etter sluttdato.

### **Skjermbilder** (hvis relevant)
![image](https://github.com/user-attachments/assets/d67e0afa-c56e-42c7-833f-497ffca9d387)

