### PR TITLE
Renamer ekstern_ref til oppgaveReferanse.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
@@ -16,11 +16,11 @@ class OppgaveService(
 
     fun håndterMottattOppgavebekreftelse(ungdomsytelseOppgavebekreftelse: UngdomsytelseOppgavebekreftelse) {
         val oppgaveBekreftelse = ungdomsytelseOppgavebekreftelse.oppgaveBekreftelse
-        val oppgaveId = UUID.fromString(oppgaveBekreftelse.søknadId.id)
+        val oppgaveReferanse = UUID.fromString(oppgaveBekreftelse.søknadId.id)
 
-        logger.info("Henter deltakelse for oppgaveId=$oppgaveId")
-        val deltakelse = deltakelseRepository.finnDeltakelseGittOppgaveId(oppgaveId) ?: throw RuntimeException("Fant ikke deltakelse for oppgaveId=$oppgaveId")
-        val oppgave = deltakelse.oppgaver.find { it.id == oppgaveId } ?: throw RuntimeException("Fant ikke oppgave for oppgaveId=$oppgaveId")
+        logger.info("Henter deltakelse for oppgaveReferanse=$oppgaveReferanse")
+        val deltakelse = deltakelseRepository.finnDeltakelseGittOppgaveReferanse(oppgaveReferanse) ?: throw RuntimeException("Fant ikke deltakelse for oppgaveReferanse=$oppgaveReferanse")
+        val oppgave = deltakelse.oppgaver.find { it.oppgaveReferanse == oppgaveReferanse } ?: throw RuntimeException("Fant ikke oppgave for oppgaveReferanse=$oppgaveReferanse")
 
         logger.info("Markerer oppgave som løst for deltakelseId=${deltakelse.id}")
         val løstOppgave = oppgave.markerSomLøst()

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -34,8 +34,8 @@ class OppgaveDAO(
     val id: UUID,
 
     @Id
-    @Column(name = "ekstern_ref", nullable = false)
-    val eksternReferanse: UUID,
+    @Column(name = "oppgave_referanse", nullable = false)
+    val oppgaveReferanse: UUID,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "deltakelse_id", nullable = false)
@@ -65,8 +65,7 @@ class OppgaveDAO(
 ) {
     companion object {
         fun OppgaveDAO.tilDTO() = OppgaveDTO(
-            id = id,
-            eksternReferanse = eksternReferanse,
+            oppgaveReferanse = oppgaveReferanse,
             oppgavetype = oppgavetype,
             oppgavetypeData = oppgavetypeDataDAO.tilDTO(),
             status = status,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
@@ -29,16 +29,6 @@ interface UngdomsprogramDeltakelseRepository : JpaRepository<UngdomsprogramDelta
         value = """
         SELECT u.* FROM ungdomsprogram_deltakelse u
         INNER JOIN oppgave o on u.id = o.deltakelse_id
-        WHERE o.id = :oppgaveId
-    """,
-        nativeQuery = true
-    )
-    fun finnDeltakelseGittOppgaveId(@Param("oppgaveId") oppgaveId: UUID): UngdomsprogramDeltakelseDAO?
-
-    @Query(
-        value = """
-        SELECT u.* FROM ungdomsprogram_deltakelse u
-        INNER JOIN oppgave o on u.id = o.deltakelse_id
         WHERE o.oppgave_referanse = :oppgaveReferanse
     """,
         nativeQuery = true

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
@@ -39,9 +39,9 @@ interface UngdomsprogramDeltakelseRepository : JpaRepository<UngdomsprogramDelta
         value = """
         SELECT u.* FROM ungdomsprogram_deltakelse u
         INNER JOIN oppgave o on u.id = o.deltakelse_id
-        WHERE o.ekstern_ref = :eksternRef
+        WHERE o.oppgave_referanse = :oppgaveReferanse
     """,
         nativeQuery = true
     )
-    fun finnDeltakelseGittOppgaveEksternReferanse(@Param("eksternRef") eksternRef: UUID): UngdomsprogramDeltakelseDAO?
+    fun finnDeltakelseGittOppgaveReferanse(@Param("oppgaveReferanse") oppgaveReferanse: UUID): UngdomsprogramDeltakelseDAO?
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -215,7 +215,7 @@ class UngdomsprogramregisterService(
         logger.info("Oppretter ny oppgave for bekreftelse av endret startdato")
         val nyOppgave = OppgaveDAO(
             id = UUID.randomUUID(),
-            eksternReferanse = UUID.randomUUID(),
+            oppgaveReferanse = UUID.randomUUID(),
             deltakelse = eksisterende,
             oppgavetype = Oppgavetype.BEKREFT_ENDRET_STARTDATO,
             oppgavetypeDataDAO = EndretStartdatoOppgavetypeDataDAO(
@@ -260,7 +260,7 @@ class UngdomsprogramregisterService(
 
         val bekreftEndretSluttdatoOppgave = OppgaveDAO(
             id = UUID.randomUUID(),
-            eksternReferanse = UUID.randomUUID(),
+            oppgaveReferanse = UUID.randomUUID(),
             oppgavetype = Oppgavetype.BEKREFT_ENDRET_SLUTTDATO,
             oppgavetypeDataDAO = EndretSluttdatoOppgavetypeDataDAO(
                 nySluttdato = endrePeriodeDatoDTO.dato,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -282,8 +282,8 @@ class UngdomsprogramregisterService(
         return oppdatertDeltakelse.mapToDTO()
     }
 
-    fun hentOppgaveForDeltakelse(personIdent: String, deltakelseId: UUID, oppgaveId: UUID): OppgaveDTO {
-        logger.info("Henter oppgave med id $oppgaveId for deltakelse med id $deltakelseId")
+    fun hentOppgaveForDeltakelse(personIdent: String, deltakelseId: UUID, oppgaveReferanse: UUID): OppgaveDTO {
+        logger.info("Henter oppgave med id $oppgaveReferanse for deltakelse med id $deltakelseId")
         val deltakerIder = deltakerService.hentDeltakterIder(personIdent)
         val deltakelse =
             deltakelseRepository.findByIdAndDeltaker_IdIn(deltakelseId, deltakerIder) ?: throw ErrorResponseException(
@@ -294,11 +294,11 @@ class UngdomsprogramregisterService(
                 null
             )
 
-        val oppgave = deltakelse.oppgaver.find { oppgave -> oppgave.id == oppgaveId } ?: run {
+        val oppgave = deltakelse.oppgaver.find { oppgave -> oppgave.id == oppgaveReferanse } ?: run {
             throw ErrorResponseException(
                 HttpStatus.NOT_FOUND,
                 ProblemDetail.forStatus(HttpStatus.NOT_FOUND).also {
-                    it.detail = "Fant ingen oppgave med id $oppgaveId for deltakelse med id $deltakelseId"
+                    it.detail = "Fant ingen oppgave med id $oppgaveReferanse for deltakelse med id $deltakelseId"
                 },
                 null
             )

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
@@ -51,11 +51,11 @@ class UngdomsprogramRegisterDeltakerController(
         return registerService.markerSomHarSøkt(id)
     }
 
-    @GetMapping("/{deltakelseId}/oppgave/{oppgaveId}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping("/{deltakelseId}/oppgave/{oppgaveReferanse}", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Henter en oppgave for en gitt deltakelse")
     @ResponseStatus(HttpStatus.OK)
-    fun hentOppgaveForDeltakelse(@PathVariable deltakelseId: UUID, @PathVariable oppgaveId: UUID): OppgaveDTO {
+    fun hentOppgaveForDeltakelse(@PathVariable deltakelseId: UUID, @PathVariable oppgaveReferanse: UUID): OppgaveDTO {
         val personIdent = tokenValidationContextHolder.personIdent()
-        return registerService.hentOppgaveForDeltakelse(personIdent, deltakelseId, oppgaveId)
+        return registerService.hentOppgaveForDeltakelse(personIdent, deltakelseId, oppgaveReferanse)
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -40,7 +40,7 @@ class OppgaveUngSakController(
     private val deltakerService: DeltakerService,
     private val deltakelseRepository: UngdomsprogramDeltakelseRepository,
 ) {
-    @PostMapping("/{oppgaveReferanse}/avbryt", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PutMapping("/{oppgaveReferanse}/avbryt", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Avbryter oppgave")
     @ResponseStatus(HttpStatus.OK)
     fun avbrytOppgave(@PathVariable oppgaveReferanse: UUID) {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -46,17 +46,13 @@ class OppgaveUngSakController(
     fun avbrytOppgave(@PathVariable oppgaveReferanse: UUID) {
 
         val deltakelse =
-            deltakelseRepository.finnDeltakelseGittOppgaveReferanse(oppgaveReferanse)
-
-        if (deltakelse == null) {
-            throw ErrorResponseException(
+            deltakelseRepository.finnDeltakelseGittOppgaveReferanse(oppgaveReferanse) ?: throw ErrorResponseException(
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR).also {
                     it.detail = "Fant ingen deltakelse med oppgave $oppgaveReferanse"
                 },
                 null
             )
-        }
 
         val oppgave = deltakelse.oppgaver.find { it.oppgaveReferanse == oppgaveReferanse }
         oppgave!!.markerSomAvbrutt()

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -13,7 +13,6 @@ import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseDAO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService.Companion.mapToDTO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppdaterOppgaveStatusDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektOppgaveDTO
@@ -41,25 +40,25 @@ class OppgaveUngSakController(
     private val deltakerService: DeltakerService,
     private val deltakelseRepository: UngdomsprogramDeltakelseRepository,
 ) {
-    @PostMapping("/avbryt", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PostMapping("/{oppgaveReferanse}/avbryt", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Avbryter oppgave")
     @ResponseStatus(HttpStatus.OK)
-    fun avbrytOppgave(@RequestBody eksternReferanse: UUID) {
+    fun avbrytOppgave(@PathVariable oppgaveReferanse: UUID) {
 
         val deltakelse =
-            deltakelseRepository.finnDeltakelseGittOppgaveEksternReferanse(eksternReferanse)
+            deltakelseRepository.finnDeltakelseGittOppgaveReferanse(oppgaveReferanse)
 
         if (deltakelse == null) {
             throw ErrorResponseException(
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR).also {
-                    it.detail = "Fant ingen deltakelse med oppgave $eksternReferanse"
+                    it.detail = "Fant ingen deltakelse med oppgave $oppgaveReferanse"
                 },
                 null
             )
         }
 
-        val oppgave = deltakelse.oppgaver.find { it.eksternReferanse == eksternReferanse }
+        val oppgave = deltakelse.oppgaver.find { it.oppgaveReferanse == oppgaveReferanse }
         oppgave!!.markerSomAvbrutt()
         deltakelse.oppdaterOppgave(oppgave);
         deltakelseRepository.save(deltakelse)
@@ -92,7 +91,7 @@ class OppgaveUngSakController(
 
         val nyOppgave = OppgaveDAO(
             id = UUID.randomUUID(),
-            eksternReferanse = opprettOppgaveDto.referanse,
+            oppgaveReferanse = opprettOppgaveDto.referanse,
             deltakelse = eksisterende,
             oppgavetype = Oppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT,
             oppgavetypeDataDAO = KontrollerRegisterInntektOppgaveTypeDataDAO(

--- a/app/src/main/resources/db/migration/V7__oppgave_referanse.sql
+++ b/app/src/main/resources/db/migration/V7__oppgave_referanse.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS oppgave
+    RENAME COLUMN ekstern_ref TO oppgave_referanse;

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
@@ -158,7 +158,7 @@ class UngdomsprogramregisterRepositoryTest {
     }
 
     @Test
-    fun `Forventer å finne deltakelse gitt oppgaveId`() {
+    fun `Forventer å finne deltakelse gitt oppgaveReferanse`() {
         val deltaker = DeltakerDAO(
             id = UUID.randomUUID(),
             deltakerIdent = "123",
@@ -173,10 +173,10 @@ class UngdomsprogramregisterRepositoryTest {
         )
         entityManager.persist(deltakelse)
 
-        val oppgaveId = UUID.randomUUID()
+        val oppgaveReferanse = UUID.randomUUID()
         deltakelse.leggTilOppgave(OppgaveDAO(
-            id = oppgaveId,
-            oppgaveReferanse = UUID.randomUUID(),
+            id = UUID.randomUUID(),
+            oppgaveReferanse = oppgaveReferanse,
             deltakelse = deltakelse,
             oppgavetype = Oppgavetype.BEKREFT_ENDRET_STARTDATO,
             oppgavetypeDataDAO = EndretStartdatoOppgavetypeDataDAO(
@@ -201,9 +201,9 @@ class UngdomsprogramregisterRepositoryTest {
         entityManager.persist(deltakelse)
         entityManager.flush()
 
-        val resultat = repository.finnDeltakelseGittOppgaveId(oppgaveId)
+        val resultat = repository.finnDeltakelseGittOppgaveReferanse(oppgaveReferanse)
         assertThat(resultat)
-            .withFailMessage("Forventet å finne deltakelse for oppgaveId %s, men fikk null", oppgaveId)
+            .withFailMessage("Forventet å finne deltakelse for oppgaveReferanse %s, men fikk null", oppgaveReferanse)
             .isNotNull
         assertThat(resultat!!.id)
             .withFailMessage("Forventet at deltakelse id skulle være %s", deltakelse.id)

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
@@ -176,7 +176,7 @@ class UngdomsprogramregisterRepositoryTest {
         val oppgaveId = UUID.randomUUID()
         deltakelse.leggTilOppgave(OppgaveDAO(
             id = oppgaveId,
-            eksternReferanse = UUID.randomUUID(),
+            oppgaveReferanse = UUID.randomUUID(),
             deltakelse = deltakelse,
             oppgavetype = Oppgavetype.BEKREFT_ENDRET_STARTDATO,
             oppgavetypeDataDAO = EndretStartdatoOppgavetypeDataDAO(
@@ -188,7 +188,7 @@ class UngdomsprogramregisterRepositoryTest {
         ))
         deltakelse.leggTilOppgave(OppgaveDAO(
             id = UUID.randomUUID(),
-            eksternReferanse = UUID.randomUUID(),
+            oppgaveReferanse = UUID.randomUUID(),
             deltakelse = deltakelse,
             oppgavetype = Oppgavetype.BEKREFT_ENDRET_SLUTTDATO,
             oppgavetypeDataDAO = EndretSluttdatoOppgavetypeDataDAO(

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
@@ -4,8 +4,7 @@ import java.time.ZonedDateTime
 import java.util.*
 
 data class OppgaveDTO(
-    val id: UUID,
-    val eksternReferanse: UUID,
+    val oppgaveReferanse: UUID,
     val oppgavetype: Oppgavetype,
     val oppgavetypeData: OppgavetypeDataDTO,
     val status: OppgaveStatus,


### PR DESCRIPTION
- Renamer oppgave kolonne `ekstern_ref` til `oppgave_referanse`.
- Oppdaterer query `finnDeltakelseGittOppgaveReferanse` til å bruke ny kolonnenavn.
- Renamer `eksternReferanse` til `oppgaveReferanse` på `OppgaveDTO`, og fjerner `id` som peker Oppgave PK,
- Refaktorerer `avbrytOppgave` endepunkt til `PUT` og tar inn `oppgaveReferanse` som del av pathVariabel.