### PR TITLE
Flytter kobling på oppgaver fra deltakelse til deltaker.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerDAO.kt
@@ -1,9 +1,12 @@
 package no.nav.ung.deltakelseopplyser.domene.deltaker
 
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseDAO
 import java.util.*
 
@@ -18,4 +21,24 @@ class DeltakerDAO(
 
     @OneToMany(mappedBy = "deltaker") // Refererer til UngdomsprogramDeltakelseDAO
     val deltakelseList: List<UngdomsprogramDeltakelseDAO> = emptyList(),
-)
+
+    // Oppgavene eies direkte av DeltakerDAO med cascade og orphanRemoval for helhetlig håndtering.
+    @OneToMany(mappedBy = "deltaker", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
+    val oppgaver: MutableSet<OppgaveDAO> = mutableSetOf()
+) {
+
+    /**
+     * Legger til en ny oppgave i samlingen.
+     */
+    fun leggTilOppgave(oppgave: OppgaveDAO) {
+        oppgaver.add(oppgave)
+    }
+
+    /**
+     * Oppdaterer en eksisterende oppgave. Oppgaven med samme id blir erstattet.
+     */
+    fun oppdaterOppgave(oppdatertOppgave: OppgaveDAO) {
+        oppgaver.removeAll { it.id == oppdatertOppgave.id }
+        oppgaver.add(oppdatertOppgave)
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepository.kt
@@ -1,9 +1,21 @@
 package no.nav.ung.deltakelseopplyser.domene.deltaker
 
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.UUID
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.*
 
-interface DeltakerRepository: JpaRepository<DeltakerDAO, UUID> {
+interface DeltakerRepository : JpaRepository<DeltakerDAO, UUID> {
     fun findByDeltakerIdent(deltakerIdent: String): DeltakerDAO?
     fun findByDeltakerIdentIn(deltakerIdenter: List<String>): List<DeltakerDAO>
+
+    @Query(
+        value = """
+        SELECT d.* FROM deltaker d
+        INNER JOIN oppgave o on d.id = o.deltaker_id
+        WHERE o.oppgave_referanse = :oppgaveReferanse
+    """,
+        nativeQuery = true
+    )
+    fun finnDeltakerGittOppgaveReferanse(@Param("oppgaveReferanse") oppgaveReferanse: UUID): DeltakerDAO?
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.pdl.generated.hentperson.Foedselsdato
 import no.nav.pdl.generated.hentperson.Navn
 import no.nav.pdl.generated.hentperson.Person
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
@@ -70,6 +71,18 @@ class DeltakerService(
         return deltakerRepository.saveAndFlush(deltakelseOpplysningDTO.deltaker.mapToDAO())
     }
 
+    fun oppdaterDeltaker(deltaker: DeltakerDAO): DeltakerDAO {
+        return deltakerRepository.save(deltaker)
+    }
+
+    fun hentDeltakersOppgaver(deltakerIdentEllerAktørId: String): List<OppgaveDAO> {
+        return hentDeltakere(deltakerIdentEllerAktørId).flatMap { it.oppgaver }
+    }
+
+    fun finnDeltakerGittOppgaveReferanse(oppgaveReferanse: UUID): DeltakerDAO? {
+        return deltakerRepository.finnDeltakerGittOppgaveReferanse(oppgaveReferanse)
+    }
+
     private fun hentDeltakerInfoMedId(id: UUID): DeltakerPersonlia? {
         val deltakerDAO = deltakerRepository.findById(id).orElseThrow {
             ErrorResponseException(
@@ -115,7 +128,7 @@ class DeltakerService(
         return deltakerRepository.findByDeltakerIdentIn(identer)
     }
 
-    private fun hentDeltakerInfoMedIdent(deltakerIdent: String): DeltakerPersonlia? {
+    private fun hentDeltakerInfoMedIdent(deltakerIdent: String): DeltakerPersonlia {
         val deltakerDAO = deltakerRepository.findByDeltakerIdent(deltakerIdent)
 
         val PdlPerson = hentPdlPerson(deltakerDAO?.deltakerIdent ?: deltakerIdent)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
@@ -1,14 +1,14 @@
 package no.nav.ung.deltakelseopplyser.domene.oppgave
 
+import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.oppgave.kafka.UngdomsytelseOppgavebekreftelse
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.util.UUID
+import java.util.*
 
 @Service
 class OppgaveService(
-    private val deltakelseRepository: UngdomsprogramDeltakelseRepository
+    private val deltakerService: DeltakerService,
 ) {
     private companion object {
         private val logger = LoggerFactory.getLogger(OppgaveService::class.java)
@@ -18,15 +18,22 @@ class OppgaveService(
         val oppgaveBekreftelse = ungdomsytelseOppgavebekreftelse.oppgaveBekreftelse
         val oppgaveReferanse = UUID.fromString(oppgaveBekreftelse.søknadId.id)
 
-        logger.info("Henter deltakelse for oppgaveReferanse=$oppgaveReferanse")
-        val deltakelse = deltakelseRepository.finnDeltakelseGittOppgaveReferanse(oppgaveReferanse) ?: throw RuntimeException("Fant ikke deltakelse for oppgaveReferanse=$oppgaveReferanse")
-        val oppgave = deltakelse.oppgaver.find { it.oppgaveReferanse == oppgaveReferanse } ?: throw RuntimeException("Fant ikke oppgave for oppgaveReferanse=$oppgaveReferanse")
+        logger.info("Henter deltakers oppgave for oppgaveReferanse=$oppgaveReferanse")
+        val deltakerIdent = oppgaveBekreftelse.søker.personIdent.verdi
+        val deltaker =
+            deltakerService.finnDeltakerGittIdent(deltakerIdent) ?: throw RuntimeException("Deltaker ikke funnet.")
 
-        logger.info("Markerer oppgave som løst for deltakelseId=${deltakelse.id}")
+        val oppgave = deltakerService.hentDeltakersOppgaver(deltaker.deltakerIdent)
+            .find { it.oppgaveReferanse == oppgaveReferanse }
+            ?: throw RuntimeException("Deltaker har ikke oppgave for oppgaveReferanse=$oppgaveReferanse")
+
+
+
+        logger.info("Markerer oppgave som løst for deltaker=${deltaker.id}")
         val løstOppgave = oppgave.markerSomLøst()
-        deltakelse.oppdaterOppgave(løstOppgave)
+        deltaker.oppdaterOppgave(løstOppgave)
 
-        deltakelseRepository.save(deltakelse)
+        deltakerService.oppdaterDeltaker(deltaker)
         // TODO: Inaktivere oppgave på mine-sider.
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseDAO
+import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.ArbeidOgFrilansRegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretSluttdatoOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretStartdatoOppgavetypeDataDTO
@@ -38,8 +38,8 @@ class OppgaveDAO(
     val oppgaveReferanse: UUID,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "deltakelse_id", nullable = false)
-    val deltakelse: UngdomsprogramDeltakelseDAO,
+    @JoinColumn(name = "deltaker_id", nullable = false)
+    val deltaker: DeltakerDAO,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "oppgavetype", nullable = false)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseDAO.kt
@@ -29,13 +29,6 @@ class UngdomsprogramDeltakelseDAO(
     @Column(name = "har_sokt")
     var harSøkt: Boolean,
 
-    /**
-     * Oppgaver som er knyttet til deltakelsen.
-     * Oppgavene knyttes til denne deltakelsen via feltet `deltakelse` i OppgaveDAO.
-     */
-    @OneToMany(mappedBy = "deltakelse", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
-    val oppgaver: MutableSet<OppgaveDAO> = mutableSetOf(),
-
     @CreatedDate
     @Column(name = "opprettet_tidspunkt")
     val opprettetTidspunkt: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
@@ -53,21 +46,6 @@ class UngdomsprogramDeltakelseDAO(
             return null
         }
         return if (periode.hasMask(Range.UPPER_EXCLUSIVE)) periode.upper().minusDays(1) else periode.upper()
-    }
-
-    /**
-     * Legger til en ny oppgave i samlingen.
-     */
-    fun leggTilOppgave(oppgave: OppgaveDAO) {
-        oppgaver.add(oppgave)
-    }
-
-    /**
-     * Oppdaterer en eksisterende oppgave. Oppgaven med samme id blir erstattet.
-     */
-    fun oppdaterOppgave(oppdatertOppgave: OppgaveDAO) {
-        oppgaver.removeAll { it.id == oppdatertOppgave.id }
-        oppgaver.add(oppdatertOppgave)
     }
 
     /**

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
@@ -24,14 +24,4 @@ interface UngdomsprogramDeltakelseRepository : JpaRepository<UngdomsprogramDelta
         @Param("deltakterIder") deltakterIder: List<UUID>,
         @Param("periodeStartdato") periodeStartdato: LocalDate
     ): UngdomsprogramDeltakelseDAO?
-
-    @Query(
-        value = """
-        SELECT u.* FROM ungdomsprogram_deltakelse u
-        INNER JOIN oppgave o on u.id = o.deltakelse_id
-        WHERE o.oppgave_referanse = :oppgaveReferanse
-    """,
-        nativeQuery = true
-    )
-    fun finnDeltakelseGittOppgaveReferanse(@Param("oppgaveReferanse") oppgaveReferanse: UUID): UngdomsprogramDeltakelseDAO?
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -92,28 +92,6 @@ class UngdomsprogramregisterService(
         return true
     }
 
-    fun oppdaterProgram(
-        id: UUID,
-        deltakelseOpplysningDTO: DeltakelseOpplysningDTO,
-    ): DeltakelseOpplysningDTO {
-        logger.info("Oppdaterer program for deltaker med $deltakelseOpplysningDTO")
-        val eksiterende = forsikreEksistererIProgram(id)
-
-        val periode = if (deltakelseOpplysningDTO.tilOgMed == null) {
-            Range.closedInfinite(deltakelseOpplysningDTO.fraOgMed)
-        } else {
-            Range.closed(deltakelseOpplysningDTO.fraOgMed, deltakelseOpplysningDTO.tilOgMed)
-        }
-
-        eksiterende.oppdaterPeriode(periode)
-
-        if (eksiterende.getTom() != null) {
-            sendEndretSluttdatoHendelseTilUngSak(eksiterende)
-        }
-
-        return deltakelseRepository.save(eksiterende).mapToDTO()
-    }
-
     fun markerSomHarSøkt(id: UUID): DeltakelseOpplysningDTO {
         logger.info("Markerer at deltaker har søkt programmet med id $id")
         val eksisterende = forsikreEksistererIProgram(id)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
@@ -50,12 +50,4 @@ class UngdomsprogramRegisterDeltakerController(
     fun markerDeltakelseSomSøkt(@PathVariable id: UUID): DeltakelseOpplysningDTO {
         return registerService.markerSomHarSøkt(id)
     }
-
-    @GetMapping("/{deltakelseId}/oppgave/{oppgaveReferanse}", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Operation(summary = "Henter en oppgave for en gitt deltakelse")
-    @ResponseStatus(HttpStatus.OK)
-    fun hentOppgaveForDeltakelse(@PathVariable deltakelseId: UUID, @PathVariable oppgaveReferanse: UUID): OppgaveDTO {
-        val personIdent = tokenValidationContextHolder.personIdent()
-        return registerService.hentOppgaveForDeltakelse(personIdent, deltakelseId, oppgaveReferanse)
-    }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -7,22 +7,27 @@ import no.nav.security.token.support.core.api.RequiredIssuers
 import no.nav.ung.deltakelseopplyser.config.Issuers
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
-import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.*
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.ArbeidOgFrilansRegisterInntektDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.KontrollerRegisterInntektOppgaveTypeDataDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO.Companion.tilDTO
-import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.RegisterinntektDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.YtelseRegisterInntektDAO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService.Companion.mapToDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektOppgaveDTO
-
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
 import org.springframework.web.ErrorResponseException
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.util.*
@@ -64,7 +69,7 @@ class OppgaveUngSakController(
     @PostMapping("/opprett", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Oppretter oppgave")
     @ResponseStatus(HttpStatus.OK)
-    fun opprettOppgaveForKontrollAvRegisterinntekt(@RequestBody opprettOppgaveDto: RegisterInntektOppgaveDTO): DeltakelseOpplysningDTO {
+    fun opprettOppgaveForKontrollAvRegisterinntekt(@RequestBody opprettOppgaveDto: RegisterInntektOppgaveDTO): OppgaveDTO {
         val deltaker = deltakerService.finnDeltakerGittIdent(opprettOppgaveDto.aktørId) ?: throw ErrorResponseException(
             HttpStatus.NOT_FOUND,
             ProblemDetail.forStatus(HttpStatus.NOT_FOUND).also {
@@ -72,9 +77,10 @@ class OppgaveUngSakController(
             },
             null
         )
-        val deltakersOppgaver = deltakerService.hentDeltakersOppgaver(opprettOppgaveDto.aktørId)
 
-        val deltakelse = forsikreEksistererIProgram(deltaker)
+        forsikreEksistererIProgram(deltaker)
+
+        val deltakersOppgaver = deltakerService.hentDeltakersOppgaver(opprettOppgaveDto.aktørId)
 
         val harUløstOppgaveForSammePeriode = deltakersOppgaver.stream()
             .anyMatch {
@@ -117,7 +123,7 @@ class OppgaveUngSakController(
 
         deltaker.leggTilOppgave(nyOppgave)
         deltakerService.oppdaterDeltaker(deltaker)
-        return deltakelse.mapToDTO()
+        return nyOppgave.tilDTO()
     }
 
     private fun gjelderSammePeriode(it: OppgaveDAO, ny: RegisterInntektOppgaveDTO): Boolean {
@@ -126,7 +132,7 @@ class OppgaveUngSakController(
         return !eksisterende.fraOgMed.isAfter(ny.tomDato) && !eksisterende.tilOgMed.isBefore(ny.fomDato)
     }
 
-    private fun forsikreEksistererIProgram(deltaker: DeltakerDAO): UngdomsprogramDeltakelseDAO {
+    private fun forsikreEksistererIProgram(deltaker: DeltakerDAO) {
         val deltakterIder = deltakerService.hentDeltakterIder(deltaker.deltakerIdent)
         val deltagelser = deltakelseRepository.findByDeltaker_IdIn(deltakterIder)
 
@@ -139,17 +145,5 @@ class OppgaveUngSakController(
                 null
             )
         }
-
-        if (deltagelser.size > 1) {
-            throw ErrorResponseException(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR).also {
-                    it.detail = "Fant flere deltakelser med id ${deltaker.id}"
-                },
-                null
-            )
-        }
-        return deltagelser.first()
     }
-
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
 import no.nav.ung.deltakelseopplyser.config.Issuers
+import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.*
@@ -45,8 +46,8 @@ class OppgaveUngSakController(
     @ResponseStatus(HttpStatus.OK)
     fun avbrytOppgave(@RequestBody oppgaveReferanse: UUID) {
 
-        val deltakelse =
-            deltakelseRepository.finnDeltakelseGittOppgaveReferanse(oppgaveReferanse) ?: throw ErrorResponseException(
+        val deltaker =
+            deltakerService.finnDeltakerGittOppgaveReferanse(oppgaveReferanse) ?: throw ErrorResponseException(
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR).also {
                     it.detail = "Fant ingen deltakelse med oppgave $oppgaveReferanse"
@@ -54,27 +55,28 @@ class OppgaveUngSakController(
                 null
             )
 
-        val oppgave = deltakelse.oppgaver.find { it.oppgaveReferanse == oppgaveReferanse }
+        val oppgave = deltaker.oppgaver.find { it.oppgaveReferanse == oppgaveReferanse }
         oppgave!!.markerSomAvbrutt()
-        deltakelse.oppdaterOppgave(oppgave);
-        deltakelseRepository.save(deltakelse)
+        deltaker.oppdaterOppgave(oppgave);
+        deltakerService.oppdaterDeltaker(deltaker)
     }
 
     @PostMapping("/opprett", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Oppretter oppgave")
     @ResponseStatus(HttpStatus.OK)
     fun opprettOppgaveForKontrollAvRegisterinntekt(@RequestBody opprettOppgaveDto: RegisterInntektOppgaveDTO): DeltakelseOpplysningDTO {
-        val hentDeltakterIder = deltakerService.hentDeltakterIder(opprettOppgaveDto.aktørId)
-        if (hentDeltakterIder.size > 1) {
-            throw IllegalStateException("Fant flere deltakelser for samme id")
-        }
-        if (hentDeltakterIder.size == 0) {
-            throw IllegalStateException("Fant ingen deltakelser for id")
-        }
+        val deltaker = deltakerService.finnDeltakerGittIdent(opprettOppgaveDto.aktørId) ?: throw ErrorResponseException(
+            HttpStatus.NOT_FOUND,
+            ProblemDetail.forStatus(HttpStatus.NOT_FOUND).also {
+                it.detail = "Fant ingen deltaker å opprette oppgave for"
+            },
+            null
+        )
+        val deltakersOppgaver = deltakerService.hentDeltakersOppgaver(opprettOppgaveDto.aktørId)
 
-        val eksisterende = forsikreEksistererIProgram(hentDeltakterIder)
+        val deltakelse = forsikreEksistererIProgram(deltaker)
 
-        val harUløstOppgaveForSammePeriode = eksisterende.oppgaver.stream()
+        val harUløstOppgaveForSammePeriode = deltakersOppgaver.stream()
             .anyMatch {
                 it.oppgavetype == Oppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT &&
                         it.status == OppgaveStatus.ULØST &&
@@ -88,7 +90,7 @@ class OppgaveUngSakController(
         val nyOppgave = OppgaveDAO(
             id = UUID.randomUUID(),
             oppgaveReferanse = opprettOppgaveDto.referanse,
-            deltakelse = eksisterende,
+            deltaker = deltaker,
             oppgavetype = Oppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT,
             oppgavetypeDataDAO = KontrollerRegisterInntektOppgaveTypeDataDAO(
                 fomDato = opprettOppgaveDto.fomDato,
@@ -113,9 +115,9 @@ class OppgaveUngSakController(
             løstDato = null
         )
 
-        eksisterende.leggTilOppgave(nyOppgave)
-        val oppdatertDeltakelse = deltakelseRepository.save(eksisterende)
-        return oppdatertDeltakelse.mapToDTO()
+        deltaker.leggTilOppgave(nyOppgave)
+        deltakerService.oppdaterDeltaker(deltaker)
+        return deltakelse.mapToDTO()
     }
 
     private fun gjelderSammePeriode(it: OppgaveDAO, ny: RegisterInntektOppgaveDTO): Boolean {
@@ -124,14 +126,15 @@ class OppgaveUngSakController(
         return !eksisterende.fraOgMed.isAfter(ny.tomDato) && !eksisterende.tilOgMed.isBefore(ny.fomDato)
     }
 
-    private fun forsikreEksistererIProgram(hentDeltakterIder: List<UUID>): UngdomsprogramDeltakelseDAO {
-        val deltagelser = deltakelseRepository.findByDeltaker_IdIn(hentDeltakterIder)
+    private fun forsikreEksistererIProgram(deltaker: DeltakerDAO): UngdomsprogramDeltakelseDAO {
+        val deltakterIder = deltakerService.hentDeltakterIder(deltaker.deltakerIdent)
+        val deltagelser = deltakelseRepository.findByDeltaker_IdIn(deltakterIder)
 
         if (deltagelser.isEmpty()) {
             throw ErrorResponseException(
                 HttpStatus.NOT_FOUND,
                 ProblemDetail.forStatus(HttpStatus.NOT_FOUND).also {
-                    it.detail = "Fant ingen deltakelse med id ${hentDeltakterIder}"
+                    it.detail = "Fant ingen deltakelse med id ${deltaker}"
                 },
                 null
             )
@@ -141,7 +144,7 @@ class OppgaveUngSakController(
             throw ErrorResponseException(
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR).also {
-                    it.detail = "Fant flere deltakelser med id ${hentDeltakterIder}"
+                    it.detail = "Fant flere deltakelser med id ${deltaker.id}"
                 },
                 null
             )

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramRegisterVeilederController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramRegisterVeilederController.kt
@@ -39,14 +39,6 @@ class UngdomsprogramRegisterVeilederController(
     private val registerService: UngdomsprogramregisterService,
 ) {
 
-    @Deprecated("Bruk /innmelding i stedet")
-    @PostMapping("/legg-til", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Operation(summary = "Legg til en ny deltakelse i ungdomsprogrammet")
-    @ResponseStatus(HttpStatus.CREATED)
-    fun leggTilIProgram(@RequestBody deltakelseOpplysningDTO: DeltakelseOpplysningDTO): DeltakelseOpplysningDTO {
-        return registerService.leggTilIProgram(deltakelseOpplysningDTO)
-    }
-
     @PostMapping(
         "/deltaker/innmelding",
         produces = [MediaType.APPLICATION_JSON_VALUE],
@@ -117,21 +109,6 @@ class UngdomsprogramRegisterVeilederController(
     @ResponseStatus(HttpStatus.OK)
     fun hentAlleDeltakelserGittDeltakerId(@PathVariable deltakerId: UUID): List<DeltakelseOpplysningDTO> {
         return registerService.hentAlleForDeltakerId(deltakerId)
-    }
-
-    @Deprecated("Bruk spesifikke endepunkter for å oppdatere en deltakelse")
-    @PutMapping(
-        "/deltakelse/{deltakelseId}/oppdater",
-        produces = [MediaType.APPLICATION_JSON_VALUE],
-        consumes = [MediaType.APPLICATION_JSON_VALUE]
-    )
-    @Operation(summary = "Oppdater opplysninger for en eksisterende deltakelse i ungdomsprogrammet")
-    @ResponseStatus(HttpStatus.OK)
-    fun oppdaterFraProgram(
-        @PathVariable deltakelseId: UUID,
-        @RequestBody deltakelseOpplysningDTO: DeltakelseOpplysningDTO,
-    ): DeltakelseOpplysningDTO {
-        return registerService.oppdaterProgram(deltakelseId, deltakelseOpplysningDTO)
     }
 
     @DeleteMapping("/deltakelse/{deltakelseId}/fjern")

--- a/app/src/main/resources/db/migration/V8__separerer_deltakelse_og_oppgave.sql
+++ b/app/src/main/resources/db/migration/V8__separerer_deltakelse_og_oppgave.sql
@@ -1,0 +1,22 @@
+-- Tømmer oppgave-tabellen
+TRUNCATE TABLE oppgave;
+
+-- Fjern koblingen mot deltakelse
+ALTER TABLE oppgave
+    DROP CONSTRAINT IF EXISTS fk_oppgaver_deltakelseId,
+    DROP COLUMN IF EXISTS deltakelse_id;
+
+-- Legg til kolonnen for kobling til deltaker
+ALTER TABLE oppgave
+    ADD COLUMN IF NOT EXISTS deltaker_id UUID;
+
+-- Legg til kobling mot deltaker
+ALTER TABLE oppgave
+    ADD CONSTRAINT fk_oppgave_deltaker FOREIGN KEY (deltaker_id)
+        REFERENCES deltaker (id);
+
+-- Legg til constraint som hindrer at en deltaker har to oppgaver med samme type og uløst status.
+-- Unntak for oppgavetype 'BEKREFT_AVVIK_REGISTERINNTEKT' da denne kan ha flere uløste oppgaver.
+CREATE UNIQUE INDEX uniq_oppgave_deltaker_oppgavetype_ulost
+    ON oppgave (deltaker_id, oppgavetype)
+    WHERE status = 'ULØST' AND oppgavetype NOT IN ('BEKREFT_AVVIK_REGISTERINNTEKT');

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepositoryTest.kt
@@ -1,0 +1,108 @@
+package no.nav.ung.deltakelseopplyser.domene.deltaker
+
+import io.hypersistence.utils.hibernate.type.range.Range
+import jakarta.persistence.EntityManager
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.EndretSluttdatoOppgavetypeDataDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.EndretStartdatoOppgavetypeDataDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
+import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseDAO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.LocalDate
+import java.util.*
+
+
+@DataJpaTest
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(SpringExtension::class)
+@AutoConfigureTestDatabase(
+    replace = AutoConfigureTestDatabase.Replace.NONE
+)
+class DeltakerRepositoryTest {
+
+    @Autowired
+    lateinit var deltakerRepository: DeltakerRepository
+
+    @Autowired
+    lateinit var entityManager: EntityManager
+
+    @BeforeEach
+    fun setUp() {
+        deltakerRepository.deleteAll()
+    }
+
+    @AfterAll
+    internal fun tearDown() {
+        deltakerRepository.deleteAll()
+    }
+
+    @Test
+    fun `Forventer å finne deltakelse gitt oppgaveReferanse`() {
+        val deltaker = DeltakerDAO(
+            id = UUID.randomUUID(),
+            deltakerIdent = "123",
+            deltakelseList = mutableListOf(),
+        )
+        entityManager.persist(deltaker)
+
+        val deltakelse = UngdomsprogramDeltakelseDAO(
+            deltaker = deltaker,
+            harSøkt = false,
+            periode = Range.closed(LocalDate.now(), LocalDate.now().plusWeeks(1))
+        )
+        entityManager.persist(deltakelse)
+
+        val oppgaveReferanse = UUID.randomUUID()
+        deltaker.leggTilOppgave(
+            OppgaveDAO(
+                id = UUID.randomUUID(),
+                oppgaveReferanse = oppgaveReferanse,
+                deltaker = deltaker,
+                oppgavetype = Oppgavetype.BEKREFT_ENDRET_STARTDATO,
+                oppgavetypeDataDAO = EndretStartdatoOppgavetypeDataDAO(
+                    nyStartdato = LocalDate.now(),
+                    veilederRef = "abc-123",
+                    meldingFraVeileder = null
+                ),
+                status = OppgaveStatus.ULØST,
+            )
+        )
+
+        deltaker.leggTilOppgave(
+            OppgaveDAO(
+                id = UUID.randomUUID(),
+                oppgaveReferanse = UUID.randomUUID(),
+                deltaker = deltaker,
+                oppgavetype = Oppgavetype.BEKREFT_ENDRET_SLUTTDATO,
+                oppgavetypeDataDAO = EndretSluttdatoOppgavetypeDataDAO(
+                    nySluttdato = LocalDate.now(),
+                    veilederRef = "abc-123",
+                    meldingFraVeileder = null
+                ),
+                status = OppgaveStatus.ULØST,
+            )
+        )
+        entityManager.persist(deltaker)
+        entityManager.flush()
+
+        val resultat = deltakerRepository.finnDeltakerGittOppgaveReferanse(oppgaveReferanse)
+        assertThat(resultat)
+            .withFailMessage("Forventet å finne deltaker for oppgaveReferanse %s, men fikk null", oppgaveReferanse)
+            .isNotNull
+        assertThat(resultat!!.id)
+            .withFailMessage("Forventet at deltaker id skulle være %s", deltaker.id)
+            .isEqualTo(deltaker.id)
+    }
+}

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
@@ -4,11 +4,6 @@ import io.hypersistence.utils.hibernate.type.range.Range
 import jakarta.persistence.EntityManager
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerRepository
-import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.EndretSluttdatoOppgavetypeDataDAO
-import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.EndretStartdatoOppgavetypeDataDAO
-import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -155,59 +150,6 @@ class UngdomsprogramregisterRepositoryTest {
         assertThat(ikkeEksisterendeDeltakelseResultat)
             .withFailMessage("Forventet å ikke finne deltakelse som starter %s", ikkeEksisterendeStartdato)
             .isNull()
-    }
-
-    @Test
-    fun `Forventer å finne deltakelse gitt oppgaveReferanse`() {
-        val deltaker = DeltakerDAO(
-            id = UUID.randomUUID(),
-            deltakerIdent = "123",
-            deltakelseList = mutableListOf(),
-        )
-        entityManager.persist(deltaker)
-
-        val deltakelse = UngdomsprogramDeltakelseDAO(
-            deltaker = deltaker,
-            harSøkt = false,
-            periode = Range.closed(LocalDate.now(), LocalDate.now().plusWeeks(1))
-        )
-        entityManager.persist(deltakelse)
-
-        val oppgaveReferanse = UUID.randomUUID()
-        deltakelse.leggTilOppgave(OppgaveDAO(
-            id = UUID.randomUUID(),
-            oppgaveReferanse = oppgaveReferanse,
-            deltakelse = deltakelse,
-            oppgavetype = Oppgavetype.BEKREFT_ENDRET_STARTDATO,
-            oppgavetypeDataDAO = EndretStartdatoOppgavetypeDataDAO(
-                nyStartdato = LocalDate.now(),
-                veilederRef = "abc-123",
-                meldingFraVeileder = null
-            ),
-            status = OppgaveStatus.ULØST,
-        ))
-        deltakelse.leggTilOppgave(OppgaveDAO(
-            id = UUID.randomUUID(),
-            oppgaveReferanse = UUID.randomUUID(),
-            deltakelse = deltakelse,
-            oppgavetype = Oppgavetype.BEKREFT_ENDRET_SLUTTDATO,
-            oppgavetypeDataDAO = EndretSluttdatoOppgavetypeDataDAO(
-                nySluttdato = LocalDate.now(),
-                veilederRef = "abc-123",
-                meldingFraVeileder = null
-            ),
-            status = OppgaveStatus.ULØST,
-        ))
-        entityManager.persist(deltakelse)
-        entityManager.flush()
-
-        val resultat = repository.finnDeltakelseGittOppgaveReferanse(oppgaveReferanse)
-        assertThat(resultat)
-            .withFailMessage("Forventet å finne deltakelse for oppgaveReferanse %s, men fikk null", oppgaveReferanse)
-            .isNotNull
-        assertThat(resultat!!.id)
-            .withFailMessage("Forventet at deltakelse id skulle være %s", deltakelse.id)
-            .isEqualTo(deltakelse.id)
     }
 
     companion object {

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -269,16 +269,6 @@ class UngdomsprogramregisterServiceTest {
         assertEquals(innmelding.deltaker, endretStartdatoDeltakelse.deltaker)
         assertThat(endretStartdatoDeltakelse.fraOgMed).isEqualTo(onsdag)
         assertThat(endretStartdatoDeltakelse.tilOgMed).isNull()
-
-        val endretStartdatoOppgavetypeDataDTO =
-            endretStartdatoDeltakelse.oppgaver.first().oppgavetypeData as EndretStartdatoOppgavetypeDataDTO
-        assertEquals(onsdag, endretStartdatoOppgavetypeDataDTO.nyStartdato)
-
-        val oppgaver = endretStartdatoDeltakelse.oppgaver
-        assertThat(oppgaver).hasSize(1)
-        val oppgave = oppgaver.first()
-        assertThat(oppgave.oppgavetype).isEqualTo(Oppgavetype.BEKREFT_ENDRET_STARTDATO)
-        assertThat((oppgave.oppgavetypeData as EndretStartdatoOppgavetypeDataDTO).veilederRef).isEqualTo("abc-123")
     }
 
     @Test
@@ -317,16 +307,6 @@ class UngdomsprogramregisterServiceTest {
         assertEquals(innmelding.deltaker, endretSluttdatoDeltakelse.deltaker)
         assertThat(endretSluttdatoDeltakelse.fraOgMed).isEqualTo(mandag)
         assertThat(endretSluttdatoDeltakelse.tilOgMed).isEqualTo(onsdag.plusWeeks(1))
-
-        val endretSluttdatoOppgavetypeDataDTO =
-            endretSluttdatoDeltakelse.oppgaver.first().oppgavetypeData as EndretSluttdatoOppgavetypeDataDTO
-        assertEquals(onsdag.plusWeeks(1), endretSluttdatoOppgavetypeDataDTO.nySluttdato)
-
-        val oppgaver = endretSluttdatoDeltakelse.oppgaver
-        assertThat(oppgaver).hasSize(1)
-        val oppgave = oppgaver.first()
-        assertThat(oppgave.oppgavetype).isEqualTo(Oppgavetype.BEKREFT_ENDRET_SLUTTDATO)
-        assertThat((oppgave.oppgavetypeData as EndretSluttdatoOppgavetypeDataDTO).veilederRef).isEqualTo("abc-123")
     }
 
     private fun mockEndrePeriodeDTO(onsdag: LocalDate) = EndrePeriodeDatoDTO(

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -269,6 +269,16 @@ class UngdomsprogramregisterServiceTest {
         assertEquals(innmelding.deltaker, endretStartdatoDeltakelse.deltaker)
         assertThat(endretStartdatoDeltakelse.fraOgMed).isEqualTo(onsdag)
         assertThat(endretStartdatoDeltakelse.tilOgMed).isNull()
+
+        val endretStartdatoOppgavetypeDataDTO =
+            endretStartdatoDeltakelse.oppgaver.first().oppgavetypeData as EndretStartdatoOppgavetypeDataDTO
+        assertEquals(onsdag, endretStartdatoOppgavetypeDataDTO.nyStartdato)
+
+        val oppgaver = endretStartdatoDeltakelse.oppgaver
+        assertThat(oppgaver).hasSize(1)
+        val oppgave = oppgaver.first()
+        assertThat(oppgave.oppgavetype).isEqualTo(Oppgavetype.BEKREFT_ENDRET_STARTDATO)
+        assertThat((oppgave.oppgavetypeData as EndretStartdatoOppgavetypeDataDTO).veilederRef).isEqualTo("abc-123")
     }
 
     @Test
@@ -307,6 +317,16 @@ class UngdomsprogramregisterServiceTest {
         assertEquals(innmelding.deltaker, endretSluttdatoDeltakelse.deltaker)
         assertThat(endretSluttdatoDeltakelse.fraOgMed).isEqualTo(mandag)
         assertThat(endretSluttdatoDeltakelse.tilOgMed).isEqualTo(onsdag.plusWeeks(1))
+
+        val endretSluttdatoOppgavetypeDataDTO =
+            endretSluttdatoDeltakelse.oppgaver.first().oppgavetypeData as EndretSluttdatoOppgavetypeDataDTO
+        assertEquals(onsdag.plusWeeks(1), endretSluttdatoOppgavetypeDataDTO.nySluttdato)
+
+        val oppgaver = endretSluttdatoDeltakelse.oppgaver
+        assertThat(oppgaver).hasSize(1)
+        val oppgave = oppgaver.first()
+        assertThat(oppgave.oppgavetype).isEqualTo(Oppgavetype.BEKREFT_ENDRET_SLUTTDATO)
+        assertThat((oppgave.oppgavetypeData as EndretSluttdatoOppgavetypeDataDTO).veilederRef).isEqualTo("abc-123")
     }
 
     private fun mockEndrePeriodeDTO(onsdag: LocalDate) = EndrePeriodeDatoDTO(


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det er behov for å frigjøre oppgavene fra deltakelse slik at de kan opprettes utenfor en deltakelsesperiode ved en etterlysning fra ung-sak. 

### **Løsning**
Løsningen blir at deltaker opprettes på deltaker. Strukturen for deltakelse dto beholdes slik at hvis det finnes flere deltakelser, så kan vi spørre ung-sak om oppgavereferansen og mappe de til riktig deltakelse. Dette er nødvendig for å vise hvilken oppgave som er knyttet til hvilken deltakelseperiode.

- Fjerner kobling til deltakelse i oppgave.
- Legger til kobling til deltaker i oppgave.

### **Andre endringer**
- Sletter utgåtte endepunkter og kode.
