### PR TITLE
Legger til støtte for innlogging av programveileder i Swagger.

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -114,3 +114,11 @@ springdoc:
     enabled: ${SWAGGER_ENABLED:false}
     disable-swagger-default-url: true
     path: swagger-ui.html
+    oauth:
+      use-pkce-with-authorization-code-grant: true
+      client-id: ${AZURE_APP_CLIENT_ID}
+      scope-separator: ","
+  oAuthFlow:
+    authorizationUrl: ${AZURE_LOGIN_URL:http://localhost:8080}/authorize
+    tokenUrl: ${AZURE_LOGIN_URL:http://localhost:8080}/token
+    apiScope: api://${AZURE_APP_CLIENT_ID:abc123}/.default

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -11,6 +11,17 @@
   "ingresses": [
     "https://ung-deltakelse-opplyser.intern.dev.nav.no"
   ],
+  "azure": {
+    "replyURLs": [
+      "https://ung-deltakelse-opplyser.intern.dev.nav.no/swagger-ui/oauth2-redirect.html"
+    ],
+    "groups": [
+      {
+        "name": "0000-CA-ung-programveileder",
+        "objectId": "37538533-e91c-4a53-b155-f4448dcada0d"
+      }
+    ]
+  },
   "inboundRules": [
     {
       "app": "tokenx-token-generator",
@@ -64,6 +75,7 @@
     "PDL_API_AZURE_SCOPE": "api://dev-fss.pdl.pdl-api/.default",
 
     "SWAGGER_ENABLED": "true",
+    "AZURE_LOGIN_URL": "https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0",
 
     "ABAC_ENABLED": "false"
   }

--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -19,6 +19,20 @@ spec:
   azure:
     application:
       enabled: true
+      allowAllUsers: false
+      claims:
+        extra:
+          - "NAVident"
+          - "azp_name"
+        groups:
+          {{ #each azure.groups as |group|}}
+            - id: {{group.objectId }}
+            {{/each}}
+      singlePageApplication: true
+      replyURLs:
+        {{ #each azure.replyURLs as |url|}}
+          - {{url }}
+          {{/each}}
   kafka:
     pool: {{kafkaPool}}
   accessPolicy:

--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -25,14 +25,14 @@ spec:
           - "NAVident"
           - "azp_name"
         groups:
-          {{ #each azure.groups as |group|}}
-            - id: {{group.objectId }}
-            {{/each}}
+          {{#each azure.groups as |group|}}
+          - id: {{group.objectId }}
+          {{/each}}
       singlePageApplication: true
       replyURLs:
-        {{ #each azure.replyURLs as |url|}}
-          - {{url }}
-          {{/each}}
+        {{#each azure.replyURLs as |url|}}
+        - {{url }}
+        {{/each}}
   kafka:
     pool: {{kafkaPool}}
   accessPolicy:

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -17,7 +17,7 @@
     ],
     "groups": [
       {
-        "name": "0000-GA-k9-drift",
+        "name": "0000-CA-ung-programveileder",
         "objectId": "TODO"
       }
     ]

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -15,7 +15,12 @@
     "replyURLs": [
       "https://ung-deltakelse-opplyser.intern.nav.no/swagger-ui/oauth2-redirect.html"
     ],
-    "groups": []
+    "groups": [
+      {
+        "name": "0000-GA-k9-drift",
+        "objectId": "TODO"
+      }
+    ]
   },
   "inboundRules": [
     {

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -11,6 +11,12 @@
   "ingresses": [
     "https://ung-deltakelse-opplyser.intern.nav.no"
   ],
+  "azure": {
+    "replyURLs": [
+      "https://ung-deltakelse-opplyser.intern.nav.no/swagger-ui/oauth2-redirect.html"
+    ],
+    "groups": []
+  },
   "inboundRules": [
     {
       "app": "ungdomsytelse-veileder",
@@ -58,6 +64,8 @@
     "NO_NAV_GATEWAYS_PDL_API_BASE_URL": "https://pdl-api.prod-fss-pub.nais.io",
     "PDL_API_AZURE_SCOPE": "api://prod-fss.pdl.pdl-api/.default",
 
+    "SWAGGER_ENABLED": "true",
+    "AZURE_LOGIN_URL": "https://login.microsoftonline.com/navno.onmicrosoft.com/oauth2/v2.0",
     "ABAC_ENABLED": "true"
   }
 }


### PR DESCRIPTION
### **Behov / Bakgrunn**
For å lettere kunne teste endepunktene via Swagger, er et ønskelig å kunne logge inn med veileder tilgang.

### **Løsning**
Implementerer OAUTH2 flyt for å kunne logge inn veileder i Swagger.
