### PR TITLE
TSFF-1433 - Legger til oppslag av deltakers aktive kontonummer i NAV.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/UngDeltakelseOpplyserApplication.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/UngDeltakelseOpplyserApplication.kt
@@ -2,10 +2,12 @@ package no.nav.ung.deltakelseopplyser
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.retry.annotation.EnableRetry
 import org.springframework.transaction.annotation.EnableTransactionManagement
 
 @EnableTransactionManagement
 @SpringBootApplication
+@EnableRetry
 class UngDeltakelseOpplyserApplication
 
 fun main(args: Array<String>) {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -5,6 +5,7 @@ import no.nav.pdl.generated.hentperson.Foedselsdato
 import no.nav.pdl.generated.hentperson.Navn
 import no.nav.pdl.generated.hentperson.Person
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
+import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
@@ -20,6 +21,7 @@ import java.util.*
 class DeltakerService(
     private val deltakerRepository: DeltakerRepository,
     private val pdlService: PdlService,
+    private val kontoregisterService: KontoregisterService,
 ) {
 
     companion object {
@@ -149,6 +151,16 @@ class DeltakerService(
     private fun Foedselsdato.toLocalDate(): LocalDate {
         return LocalDate.parse(foedselsdato.toString())
     }
+
+    fun hentKontonummer(): KontonummerDTO {
+        return KontonummerDTO(
+            kontonummer = kontoregisterService.hentAktivKonto().kontonummer
+        )
+    }
+
+    data class KontonummerDTO(
+        val kontonummer: String,
+    )
 
     data class DeltakerPersonlia(
         val id: UUID? = null,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -8,6 +8,7 @@ import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.KontonummerDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -157,10 +158,6 @@ class DeltakerService(
             kontonummer = kontoregisterService.hentAktivKonto().kontonummer
         )
     }
-
-    data class KontonummerDTO(
-        val kontonummer: String,
-    )
 
     data class DeltakerPersonlia(
         val id: UUID? = null,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/DeltakerRegisterInfoController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/DeltakerRegisterInfoController.kt
@@ -27,7 +27,7 @@ class DeltakerRegisterInfoController(
     private val deltakerService: DeltakerService,
 ) {
 
-    @GetMapping("/aktiv-kontonummer", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping("/hent-kontonummer", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Henter kontonummer for en deltaker i ungdomsprogrammet")
     @ResponseStatus(HttpStatus.OK)
     fun hentAlleMineDeltakelser(): DeltakerService.KontonummerDTO {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/DeltakerRegisterInfoController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/DeltakerRegisterInfoController.kt
@@ -30,7 +30,7 @@ class DeltakerRegisterInfoController(
     @GetMapping("/hent-kontonummer", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Henter kontonummer for en deltaker i ungdomsprogrammet")
     @ResponseStatus(HttpStatus.OK)
-    fun hentAlleMineDeltakelser(): DeltakerService.KontonummerDTO {
+    fun hentKontonummer(): DeltakerService.KontonummerDTO {
         return deltakerService.hentKontonummer()
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/DeltakerRegisterInfoController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/DeltakerRegisterInfoController.kt
@@ -6,6 +6,7 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
 import no.nav.ung.deltakelseopplyser.config.Issuers.TOKEN_X
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
+import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.KontonummerDTO
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -30,7 +31,7 @@ class DeltakerRegisterInfoController(
     @GetMapping("/hent-kontonummer", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Henter kontonummer for en deltaker i ungdomsprogrammet")
     @ResponseStatus(HttpStatus.OK)
-    fun hentKontonummer(): DeltakerService.KontonummerDTO {
+    fun hentKontonummer(): KontonummerDTO {
         return deltakerService.hentKontonummer()
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/DeltakerRegisterInfoController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/DeltakerRegisterInfoController.kt
@@ -1,0 +1,36 @@
+package no.nav.ung.deltakelseopplyser.domene.register.deltaker
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.api.RequiredIssuers
+import no.nav.ung.deltakelseopplyser.config.Issuers.TOKEN_X
+import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/deltaker")
+@RequiredIssuers(
+    ProtectedWithClaims(
+        issuer = TOKEN_X,
+        claimMap = ["acr=Level4", "acr=idporten-loa-high"],
+        combineWithOr = true
+    )
+)
+@Tag(name = "Deltaker", description = "API for å hente registeropplysninger om deltaker i ungdomsprogrammet")
+class DeltakerRegisterInfoController(
+    private val deltakerService: DeltakerService,
+) {
+
+    @GetMapping("/aktiv-kontonummer", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(summary = "Henter kontonummer for en deltaker i ungdomsprogrammet")
+    @ResponseStatus(HttpStatus.OK)
+    fun hentAlleMineDeltakelser(): DeltakerService.KontonummerDTO {
+        return deltakerService.hentKontonummer()
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterKlientKonfig.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterKlientKonfig.kt
@@ -1,0 +1,62 @@
+package no.nav.ung.deltakelseopplyser.integration.kontoregister
+
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties
+import no.nav.ung.deltakelseopplyser.http.MDCValuesPropagatingClientHttpRequestInterceptor
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders.CONTENT_TYPE
+import org.springframework.http.HttpRequest
+import org.springframework.http.MediaType
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.web.client.RestTemplate
+import java.time.Duration
+
+@Configuration
+class KontoregisterKlientKonfig(
+    @Value("\${no.nav.gateways.sokos-kontoregister-person-base-url}") private val kontoregisterBaseUrl: String,
+    oauth2Config: ClientConfigurationProperties,
+    private val oAuth2AccessTokenService: OAuth2AccessTokenService,
+) {
+
+    private companion object {
+        val logger: Logger = LoggerFactory.getLogger(KontoregisterKlientKonfig::class.java)
+
+        const val TOKENX_SOKOS_KONTOREGISTER_PERSON = "tokenx-sokos-kontoregister-person"
+    }
+
+    private val tokenxSokosKontoregisterClientProperties =
+        oauth2Config.registration[TOKENX_SOKOS_KONTOREGISTER_PERSON]
+            ?: throw RuntimeException("could not find oauth2 client config for $TOKENX_SOKOS_KONTOREGISTER_PERSON")
+
+    @Bean(name = ["kontoregisterKlient"])
+    fun restTemplate(
+        builder: RestTemplateBuilder,
+        mdcInterceptor: MDCValuesPropagatingClientHttpRequestInterceptor,
+    ): RestTemplate {
+        return builder
+            .connectTimeout(Duration.ofSeconds(20))
+            .readTimeout(Duration.ofSeconds(20))
+            .defaultHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .rootUri(kontoregisterBaseUrl)
+            .defaultMessageConverters()
+            .interceptors(bearerTokenInterceptor(), mdcInterceptor)
+            .build()
+    }
+
+    private fun bearerTokenInterceptor(): ClientHttpRequestInterceptor {
+        return ClientHttpRequestInterceptor { request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution ->
+            oAuth2AccessTokenService.getAccessToken(tokenxSokosKontoregisterClientProperties).access_token?.let {
+                request.headers.setBearerAuth(it)
+            } ?: throw SecurityException("Access token er null")
+
+            execution.execute(request, body)
+        }
+    }
+}
+

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
@@ -17,6 +17,12 @@ import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestTemplate
 import java.net.URI
 
+/**
+ * Service for å hente kontonummer fra kontoregisteret.
+ *
+ * Se [Kontoregister borger-API](https://sokos-kontoregister-person.intern.dev.nav.no/api/borger/v1/docs/#/kontoregister.v1) for mer informasjon.
+ */
+
 @Retryable(
     noRetryFor = [KontoregisterException::class, HttpClientErrorException.Unauthorized::class, HttpClientErrorException.Forbidden::class, ResourceAccessException::class],
     backoff = Backoff(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
@@ -1,0 +1,95 @@
+package no.nav.ung.deltakelseopplyser.integration.kontoregister
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Recover
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Service
+import org.springframework.web.ErrorResponseException
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpServerErrorException
+import org.springframework.web.client.ResourceAccessException
+import org.springframework.web.client.RestTemplate
+import java.net.URI
+
+@Retryable(
+    noRetryFor = [KontoregisterException::class, HttpClientErrorException.Unauthorized::class, HttpClientErrorException.Forbidden::class, ResourceAccessException::class],
+    backoff = Backoff(
+        delayExpression = "\${spring.rest.retry.initialDelay}",
+        multiplierExpression = "\${spring.rest.retry.multiplier}",
+        maxDelayExpression = "\${spring.rest.retry.maxDelay}"
+    ),
+    maxAttemptsExpression = "\${spring.rest.retry.maxAttempts}",
+
+    )
+@Service
+class KontoregisterService(@Qualifier("kontoregisterKlient") private val kontoregisterKlient: RestTemplate) {
+    private companion object {
+        private val logger: Logger = LoggerFactory.getLogger(KontoregisterService::class.java)
+
+        const val TJENESTE_NAVN = "sokos-kontoregister-person"
+
+        private val hentAktivKontoUrl = "/api/borger/v1/hent-aktiv-konto"
+    }
+
+    fun hentAktivKonto(): Konto {
+        val response = kontoregisterKlient.exchange(
+            hentAktivKontoUrl,
+            HttpMethod.GET,
+            null,
+            Konto::class.java
+        )
+        return response.body!!
+    }
+
+    @Recover
+    private fun hentAktivKonto(
+        exception: HttpClientErrorException,
+    ): Konto {
+        logger.error("Fikk en HttpClientErrorException ved kall mot $TJENESTE_NAVN. Error response = '${exception.responseBodyAsString}'")
+        throw exception
+    }
+
+    @Recover
+    private fun hentAktivKonto(
+        exception: HttpServerErrorException,
+    ): Boolean {
+        logger.error("Fikk en HttpServerErrorException ved oppslag mot $TJENESTE_NAVN. Error response = '${exception.responseBodyAsString}'")
+        throw exception
+    }
+
+    @Recover
+    private fun hentAktivKonto(
+        exception: ResourceAccessException,
+    ): Konto {
+        logger.error("Fikk en ResourceAccessException oppslag mot $TJENESTE_NAVN. Error response = '${exception.message}'")
+        throw exception
+    }
+}
+
+data class Konto(val kontonummer: String)
+
+class KontoregisterException(
+    melding: String,
+    httpStatus: HttpStatus,
+) : ErrorResponseException(httpStatus, asProblemDetail(melding, httpStatus), null) {
+    private companion object {
+        private fun asProblemDetail(
+            melding: String,
+            httpStatus: HttpStatus,
+        ): ProblemDetail {
+            val problemDetail = ProblemDetail.forStatus(httpStatus)
+            problemDetail.title = "Feil ved kall mot sokos-kontoregister-person"
+            problemDetail.detail = melding
+
+            problemDetail.type = URI("/problem-details/sokos-kontoregister-person")
+
+            return problemDetail
+        }
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
@@ -25,15 +25,22 @@ import java.net.URI
  */
 
 @Retryable(
-    noRetryFor = [KontoregisterException::class, HttpClientErrorException.Unauthorized::class, HttpClientErrorException.Forbidden::class, ResourceAccessException::class],
+    noRetryFor = [
+        HttpClientErrorException.BadRequest::class,
+        HttpClientErrorException.Unauthorized::class,
+        HttpClientErrorException.Forbidden::class,
+        HttpClientErrorException.NotFound::class,
+        HttpClientErrorException.MethodNotAllowed::class,
+        ResourceAccessException::class,
+        KontoregisterException::class
+    ],
     backoff = Backoff(
         delayExpression = "\${spring.rest.retry.initialDelay}",
         multiplierExpression = "\${spring.rest.retry.multiplier}",
         maxDelayExpression = "\${spring.rest.retry.maxDelay}"
     ),
     maxAttemptsExpression = "\${spring.rest.retry.maxAttempts}",
-
-    )
+)
 @Service
 class KontoregisterService(
     @Qualifier("kontoregisterKlient") private val kontoregisterKlient: RestTemplate,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
@@ -26,11 +26,6 @@ import java.net.URI
 
 @Retryable(
     noRetryFor = [
-        HttpClientErrorException.BadRequest::class,
-        HttpClientErrorException.Unauthorized::class,
-        HttpClientErrorException.Forbidden::class,
-        HttpClientErrorException.NotFound::class,
-        HttpClientErrorException.MethodNotAllowed::class,
         ResourceAccessException::class,
         KontoregisterException::class
     ],

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
@@ -65,21 +65,21 @@ class KontoregisterService(
     }
 
     @Recover
-    fun recoverClientError(ex: HttpClientErrorException): Konto {
+    open fun hentAktivKonto(ex: HttpClientErrorException): Konto {
         val feilmelding = parseFeilmelding(ex.responseBodyAsString)
         logger.warn("Klientfeil ${ex.statusCode} mot $TJENESTE_NAVN: $feilmelding")
         throw KontoregisterException(feilmelding, HttpStatus.valueOf(ex.statusCode.value()))
     }
 
     @Recover
-    fun recoverServerError(ex: HttpServerErrorException): Konto {
+    open fun recoverServerError(ex: HttpServerErrorException): Konto {
         val feilmelding = parseFeilmelding(ex.responseBodyAsString)
         logger.error("Serverfeil ${ex.statusCode} mot $TJENESTE_NAVN: $feilmelding")
         throw KontoregisterException("Annen feil: $feilmelding", HttpStatus.valueOf(ex.statusCode.value()))
     }
 
     @Recover
-    fun recoverResourceAccess(ex: ResourceAccessException): Konto {
+    open fun recoverResourceAccess(ex: ResourceAccessException): Konto {
         logger.error("Tilgangsfeil mot $TJENESTE_NAVN: ${ex.message}")
         throw KontoregisterException(
             "Kunne ikke nå kontoregisteret: ${ex.message}",

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
@@ -64,7 +64,7 @@ class KontoregisterService(@Qualifier("kontoregisterKlient") private val kontore
     @Recover
     private fun hentAktivKonto(
         exception: HttpServerErrorException,
-    ): Boolean {
+    ): Konto {
         logger.error("Fikk en HttpServerErrorException ved oppslag mot $TJENESTE_NAVN. Error response = '${exception.responseBodyAsString}'")
         throw exception
     }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
   application:
     name: # Settes i nais/<cluster>.json
-
   flyway:
     enabled: true
   jpa:
@@ -17,6 +16,13 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+
+  rest:
+    retry:
+      multiplier: 2
+      initialDelay: 1000
+      maxDelay: 4000
+      maxAttempts: 3
 
   kafka:
     bootstrap-servers: ${KAFKA_BROKERS}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -90,6 +90,7 @@ no.nav:
               client-auth-method: private_key_jwt
               client-id: ${AZURE_APP_CLIENT_ID}
               client-jwk: ${AZURE_APP_JWK}
+
           azure-sif-abac-pdp:
             token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
             grant-type: client_credentials
@@ -98,6 +99,7 @@ no.nav:
               client-auth-method: private_key_jwt
               client-id: ${AZURE_APP_CLIENT_ID}
               client-jwk: ${AZURE_APP_JWK}
+
           azure-pdl-api:
             token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
             grant-type: client_credentials
@@ -107,9 +109,20 @@ no.nav:
               client-id: ${AZURE_APP_CLIENT_ID}
               client-jwk: ${AZURE_APP_JWK}
 
+          tokenx-sokos-kontoregister-person:
+            token-endpoint-url: ${TOKEN_X_TOKEN_ENDPOINT}
+            grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+            authentication:
+              client-auth-method: private_key_jwt
+              client-id: ${TOKEN_X_CLIENT_ID}
+              client-jwk: ${TOKEN_X_PRIVATE_JWK}
+            token-exchange:
+              audience: ${SOKOS_KONTOREGISTER_PERSON_AUDIENCE}
+
   gateways:
     ung-sak: # Settes i nais/<cluster>.json
     pdl-api-base-url: # Settes i nais/<cluster>.json
+    sokos-kontoregister-person-base-url: # Settes i nais/<cluster>.json
 
 springdoc:
   api-docs:

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService.Companion.rapporteringsPerioder
+import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngSakService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
@@ -61,6 +62,9 @@ class UngdomsprogramregisterServiceTest {
 
     @MockkBean(relaxed = true)
     lateinit var ungSakService: UngSakService
+
+    @MockkBean(relaxed = true)
+    lateinit var kontoregisterService: KontoregisterService
 
     @MockkBean(relaxed = true)
     lateinit var pdlService: PdlService

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
@@ -20,6 +20,7 @@ import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.soknad.kafka.Ungdomsytelsesøknad
+import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -54,6 +55,9 @@ class UngdomsytelsesøknadServiceTest {
 
     @MockkBean
     lateinit var ungSakService: UngSakService
+
+    @MockkBean
+    lateinit var kontoregisterService: KontoregisterService
 
     @Autowired
     lateinit var ungdomsprogramDeltakelseRepository: UngdomsprogramDeltakelseRepository

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -72,7 +72,18 @@ no.nav:
               client-id: dev-gcp:k9saksbehandling:ung-deltakelse-opplyser
               client-jwk: src/test/resources/private_jwk.json
 
+          tokenx-sokos-kontoregister-person:
+            token-endpoint-url: http://localhost:${mock-oauth2-server.port}/oauth2/v2.0/token
+            grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+            authentication:
+              client-auth-method: private_key_jwt
+              client-id: dev-gcp:k9saksbehandling:ung-deltakelse-opplyser
+              client-jwk: src/test/resources/private_jwk.json
+            token-exchange:
+              audience: dev-gcp:okonomi:sokos-kontoregister-person
+
   gateways:
     ung-sak: http://localhost:${wiremock.server.port}/ung-sak-mock/k9/sak
     sif-abac-pdp: http://localhost:${wiremock.server.port}/sif-abac-pdp-mock
     pdl-api-base-url: http://localhost:${wiremock.server.port}/pdl-api-mock
+    sokos-kontoregister-person-base-url: http://localhost:${wiremock.server.port}/sokos-kontoregister-person-mock

--- a/dev/vtp.env
+++ b/dev/vtp.env
@@ -29,6 +29,10 @@ UNG_SAK_AZURE_SCOPE=api://vtp.k9saksbehandling.ung-sak/.default
 NO_NAV_GATEWAYS_SIF_ABAC_PDP=http://localhost:8913/sif/sif-abac-pdp/api/tilgangskontroll/ung",
 SIF_ABAC_PDP_AZURE_SCOPE=api://vtp.k9saksbehandling.sif-abac-pdp/.default",
 
+# Settes bare for å ikke feile ved lesing av config. Denne url-en fungerer ikke da det ikke er noe mock for denne tjenesten.
+NO_NAV_GATEWAYS_SOKOS_KONTOREGISTER_PERSON_BASE_URL=http://localhost:8901
+SOKOS_KONTOREGISTER_PERSON_AUDIENCE=dev-gcp:okonomi:sokos-kontoregister-person
+
 # Kafka
 KAFKA_BROKERS=localhost:9093
 KAFKA_TRUSTSTORE_PATH=${user.home}/.modig/truststore.jks

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/KontonummerDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/KontonummerDTO.kt
@@ -1,0 +1,5 @@
+package no.nav.ung.deltakelseopplyser.kontrakt.deltaker
+
+data class KontonummerDTO(
+    val kontonummer: String,
+)

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -79,6 +79,9 @@
     "NO_NAV_GATEWAYS_PDL_API_BASE_URL": "https://pdl-api.dev-fss-pub.nais.io",
     "PDL_API_AZURE_SCOPE": "api://dev-fss.pdl.pdl-api/.default",
 
+    "NO_NAV_GATEWAYS_SOKOS_KONTOREGISTER_PERSON_BASE_URL": "http://sokos-kontoregister-person.okonomi",
+    "SOKOS_KONTOREGISTER_PERSON_AUDIENCE": "dev-gcp:okonomi:sokos-kontoregister-person",
+
     "UNGDOMSYTELSE_DELTAKER_BASE_URL": "https://ungdomsytelse-deltaker.intern.dev.nav.no/ungdomsytelse-deltaker",
 
     "SWAGGER_ENABLED": "true",

--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -47,6 +47,8 @@ spec:
       rules:
         - application: k9-selvbetjening-oppslag
         - application: sif-abac-pdp
+        - application: sokos-kontoregister-person
+          namespace: okonomi
       external:
         {{#each externalHosts as |host|}}
         - host: {{host}}

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -69,6 +69,9 @@
     "NO_NAV_GATEWAYS_PDL_API_BASE_URL": "https://pdl-api.prod-fss-pub.nais.io",
     "PDL_API_AZURE_SCOPE": "api://prod-fss.pdl.pdl-api/.default",
 
+    "SOKOS_KONTOREGISTER_PERSON_BASE_URL": "http://sokos-kontoregister-person.okonomi",
+    "SOKOS_KONTOREGISTER_PERSON_AUDIENCE": "prod-gcp:okonomi:sokos-kontoregister-person",
+
     "UNGDOMSYTELSE_DELTAKER_BASE_URL": "https://www.nav.no/ungdomsytelse-deltaker",
 
     "SWAGGER_ENABLED": "true",


### PR DESCRIPTION
### **Behov / Bakgrunn**
Enten det er snakk om en ny NAV bruker eller eksisterende som nylig har fylt 18 år, vil de ikke ha en aktiv kontonummer hos NAV.
Når deltaker er innmeldt i programmet og deretter skal søke, skal man sjekke om de er registrert med aktiv kontonummer hos NAV slik at man får til en effektiv utbetaling av pengene.

### **Løsning**
- Integrerer mot [sokos-kontoregister-person](https://github.com/navikt/sokos-kontoregister-person/blob/main/dokumentasjon/API.md#borger-api-innlogget-p%C3%A5-vegne-av-en-bruker) for oppslag av aktiv kontonummer hos NAV.
- Legger til ny controller med endepunkt for å hente registrert kontonummer.

### **Andre endringer**
- Aktiverer spring-retry som gjør muliggjør retry av servicekall.