### PR TITLE
Håndterer HTTP 404 feil ved henting av kontonummer.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -154,9 +154,7 @@ class DeltakerService(
     }
 
     fun hentKontonummer(): KontonummerDTO {
-        return KontonummerDTO(
-            kontonummer = kontoregisterService.hentAktivKonto().kontonummer
-        )
+        return kontoregisterService.hentAktivKonto()
     }
 
     data class DeltakerPersonlia(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterService.kt
@@ -59,7 +59,7 @@ class KontoregisterService(
         )
         val konto = response.body!!
         return KontonummerDTO(
-            harKontonummmer = true,
+            harKontonummer = true,
             kontonummer = konto.kontonummer
         )
     }
@@ -70,7 +70,7 @@ class KontoregisterService(
         logger.warn("Klientfeil ${ex.statusCode} mot $TJENESTE_NAVN: $feilmelding")
 
         if (ex.statusCode == HttpStatus.NOT_FOUND) {
-            return KontonummerDTO(harKontonummmer = false)
+            return KontonummerDTO(harKontonummer = false)
         }
 
         throw KontoregisterException(feilmelding, HttpStatus.valueOf(ex.statusCode.value()))

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterServiceTest.kt
@@ -1,0 +1,100 @@
+package no.nav.ung.deltakelseopplyser.integration.kontoregister
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.ninjasquad.springmockk.MockkBean
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import no.nav.ung.deltakelseopplyser.utils.TokenTestUtils.mockContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.net.URI
+
+@AutoConfigureWireMock
+@EnableMockOAuth2Server
+@ExtendWith(SpringExtension::class)
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class KontoregisterServiceTest {
+
+    @Autowired
+    lateinit var kontoregisterService: KontoregisterService
+
+    @Autowired
+    lateinit var wireMockServer: WireMockServer
+
+    @MockkBean
+    private lateinit var springTokenValidationContextHolder: SpringTokenValidationContextHolder
+
+    @BeforeEach
+    fun setUp() {
+        springTokenValidationContextHolder.mockContext()
+    }
+
+    private companion object {
+        val KONTOREGISTER_BASE_PATH = "/sokos-kontoregister-person-mock/api/borger/v1"
+    }
+
+    @Test
+    fun `Forventer kontonummer gitt OK respons`() {
+        mockHentKontonummer(
+            statusKode = HttpStatus.OK.value(),
+            // language=json
+            body = """{"kontonummer":"12345678901"}"""
+        )
+
+        val kontonummerDTO = kontoregisterService.hentAktivKonto()
+        assertThat(kontonummerDTO.harKontonummmer).isTrue()
+        assertThat(kontonummerDTO.kontonummer).isEqualTo("12345678901")
+    }
+
+    @Test
+    fun `Forventer ikke kontonummer gitt ikke-funnet respons`() {
+        mockHentKontonummer(
+            statusKode = HttpStatus.NOT_FOUND.value(),
+            // language=json
+            body = """{"feilmelding": "person ikke funnet i kontoregister"}"""
+        )
+
+        val kontonummerDTO = kontoregisterService.hentAktivKonto()
+        assertThat(kontonummerDTO.harKontonummmer).isFalse()
+        assertThat(kontonummerDTO.kontonummer).isNull()
+    }
+
+    @Test
+    fun `Forventer at det kastes feil ved andre feil`() {
+        mockHentKontonummer(
+            statusKode = HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            body = """{"feilmelding": "Noe har gått galt"}"""
+        )
+
+        val kontoregisterException = assertThrows<KontoregisterException> { kontoregisterService.hentAktivKonto() }
+        assertThat(kontoregisterException.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(kontoregisterException.body.type).isEqualTo(URI("/problem-details/sokos-kontoregister-person"))
+        assertThat(kontoregisterException.body.title).isEqualTo("Feil ved kall mot sokos-kontoregister-person")
+        assertThat(kontoregisterException.body.detail).isEqualTo("Annen feil: Noe har gått galt")
+    }
+
+    private fun mockHentKontonummer(statusKode: Int, body: String?) {
+        val responseDefinitionBuilder = WireMock.aResponse()
+            .withStatus(statusKode)
+            .withHeader("Content-Type", "application/json")
+
+        body?.let { responseDefinitionBuilder.withBody(it) }
+
+        wireMockServer.stubFor(
+            WireMock.get(
+                WireMock.urlPathEqualTo("${KONTOREGISTER_BASE_PATH}/hent-aktiv-konto")
+            ).willReturn(responseDefinitionBuilder)
+        )
+    }
+}

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterServiceTest.kt
@@ -53,7 +53,7 @@ class KontoregisterServiceTest {
         )
 
         val kontonummerDTO = kontoregisterService.hentAktivKonto()
-        assertThat(kontonummerDTO.harKontonummmer).isTrue()
+        assertThat(kontonummerDTO.harKontonummer).isTrue()
         assertThat(kontonummerDTO.kontonummer).isEqualTo("12345678901")
     }
 
@@ -66,7 +66,7 @@ class KontoregisterServiceTest {
         )
 
         val kontonummerDTO = kontoregisterService.hentAktivKonto()
-        assertThat(kontonummerDTO.harKontonummmer).isFalse()
+        assertThat(kontonummerDTO.harKontonummer).isFalse()
         assertThat(kontonummerDTO.kontonummer).isNull()
     }
 

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenTestUtils.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenTestUtils.kt
@@ -1,10 +1,16 @@
 package no.nav.ung.deltakelseopplyser.utils
 
 import com.nimbusds.jwt.SignedJWT
+import io.mockk.every
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.ung.deltakelseopplyser.config.Issuers.TOKEN_X
 
 object TokenTestUtils {
+    const val MOCK_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
     fun MockOAuth2Server.hentToken(
         subject: String = "12345678910",
         issuerId: String = TOKEN_X,
@@ -13,4 +19,8 @@ object TokenTestUtils {
         expiry: Long = 3600,
     ): SignedJWT =
         issueToken(issuerId = issuerId, subject = subject, claims = claims, audience = audience, expiry = expiry)
+
+    fun SpringTokenValidationContextHolder.mockContext(encodedToken: String = MOCK_TOKEN) {
+        every { getTokenValidationContext() } returns TokenValidationContext(mapOf("1234567890" to JwtToken(encodedToken)))
+    }
 }

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -87,3 +87,8 @@ no.nav:
     sif-abac-pdp: http://localhost:${wiremock.server.port}/sif-abac-pdp-mock
     pdl-api-base-url: http://localhost:${wiremock.server.port}/pdl-api-mock
     sokos-kontoregister-person-base-url: http://localhost:${wiremock.server.port}/sokos-kontoregister-person-mock
+
+wiremock:
+  reset-mappings-after-each-test: true
+  server:
+    port: 0 # random port

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/KontonummerDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/KontonummerDTO.kt
@@ -1,6 +1,6 @@
 package no.nav.ung.deltakelseopplyser.kontrakt.deltaker
 
 data class KontonummerDTO(
-    val harKontonummmer: Boolean,
+    val harKontonummer: Boolean,
     val kontonummer: String? = null,
 )

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/KontonummerDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/KontonummerDTO.kt
@@ -1,5 +1,6 @@
 package no.nav.ung.deltakelseopplyser.kontrakt.deltaker
 
 data class KontonummerDTO(
-    val kontonummer: String,
+    val harKontonummmer: Boolean,
+    val kontonummer: String? = null,
 )


### PR DESCRIPTION
### **Behov / Bakgrunn**
Kontoregister returnerer 404 feil dersom deltaker ikke har registrert kontonummer i NAV.
Dette propageres videre og gir ikke meningsfullt respons til frontend.

### **Løsning**
- Utvider `KontonummerDTO` med et ekstra felt `harKontonummer` og setter `kontonummer` til nullable.
- Ved HTTP 404 feil returnerer `KontoregisterService` `KontonummerDTO` med harKontonummer false, og `kontonummer` null.

### **Andre endringer**
- Tester at `KontoregisterService` fungerer som tiltenkt.
- Legger til util for å kunne mocke token i context når restTemplate skal exchange token og gjøre tjenestekall.