### PR TITLE
Lagrer ned og mapper oppgave bekreftelse med uttalelse.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
@@ -1,6 +1,6 @@
 package no.nav.ung.deltakelseopplyser.domene.oppgave
 
-import no.nav.k9.oppgave.OppgaveBekreftelse
+import no.nav.k9.oppgave.OppgaveBekreftelse as UngOppgaveBekreftelse
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse
 import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretProgramperiodeBekreftelse
@@ -42,7 +42,11 @@ class OppgaveService(
         oppgave.markerSomLøst()
 
         forsikreRiktigOppgaveBekreftelse(oppgave, oppgaveBekreftelse)
-        oppgave.oppgaveBekreftelse = oppgaveBekreftelse
+        val bekreftelse = oppgaveBekreftelse.getBekreftelse<Bekreftelse>()
+        oppgave.oppgaveBekreftelse = no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveBekreftelse(
+            harGodtattEndringen = bekreftelse.harBrukerGodtattEndringen(),
+            uttalelseFraBruker = bekreftelse.uttalelseFraBruker
+        )
 
         deltakerService.oppdaterDeltaker(deltaker)
 
@@ -52,7 +56,7 @@ class OppgaveService(
 
     private fun forsikreRiktigOppgaveBekreftelse(
         oppgave: OppgaveDAO,
-        oppgaveBekreftelse: OppgaveBekreftelse,
+        oppgaveBekreftelse: UngOppgaveBekreftelse,
     ) = when (oppgave.oppgavetype) {
         Oppgavetype.BEKREFT_AVVIK_REGISTERINNTEKT ->
             oppgaveBekreftelse.getBekreftelse() as? InntektBekreftelse
@@ -67,8 +71,5 @@ class OppgaveService(
                     "For oppgavetype=${oppgave.oppgavetype} forventet EndretProgramperiodeBekreftelse, " +
                             "men fikk ${oppgaveBekreftelse.getBekreftelse<Bekreftelse>()::class.simpleName}"
                 )
-
-        else ->
-            throw IllegalArgumentException("Ukjent oppgavetype=${oppgave.oppgavetype}")
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveBekreftelse.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveBekreftelse.kt
@@ -1,0 +1,6 @@
+package no.nav.ung.deltakelseopplyser.domene.oppgave.repository
+
+class OppgaveBekreftelse(
+    val harGodtattEndringen: Boolean,
+    val uttalelseFraBruker: String? = null,
+)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -9,9 +9,19 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import no.nav.k9.oppgave.OppgaveBekreftelse
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.*
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.EndretProgamperiodeOppgaveDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.ArbeidOgFrilansRegisterInntektDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.BekreftelseDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.RegisterinntektDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.YtelseRegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.ProgramperiodeDTO
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.annotations.Type
@@ -50,21 +60,36 @@ class OppgaveDAO(
     @Column(name = "oppgavetype_data", columnDefinition = "jsonb")
     val oppgavetypeDataDAO: OppgavetypeDataDAO,
 
+    @Type(JsonBinaryType::class)
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "oppgave_bekreftelse", columnDefinition = "jsonb")
+    var oppgaveBekreftelse: OppgaveBekreftelse? = null,
+
     @Column(name = "opprettet_dato", nullable = false)
     val opprettetDato: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC),
 
     @Column(name = "løst_dato")
     var løstDato: ZonedDateTime? = null,
 ) {
+
     companion object {
         fun OppgaveDAO.tilDTO() = OppgaveDTO(
             oppgaveReferanse = oppgaveReferanse,
             oppgavetype = oppgavetype,
             oppgavetypeData = oppgavetypeDataDAO.tilDTO(),
+            bekreftelse = oppgaveBekreftelse?.tilDTO(),
             status = status,
             opprettetDato = opprettetDato,
             løstDato = løstDato
         )
+
+        fun OppgaveBekreftelse.tilDTO(): BekreftelseDTO {
+            val bekreftelse = getBekreftelse<Bekreftelse>()
+            return BekreftelseDTO(
+                harGodtattEndringen = bekreftelse.harBrukerGodtattEndringen(),
+                uttalelseFraBruker = bekreftelse.uttalelseFraBruker,
+            )
+        }
 
         fun OppgavetypeDataDAO.tilDTO(): OppgavetypeDataDTO = when (this) {
             is EndretProgramperiodeOppgavetypeDataDAO -> EndretProgramperiodeDataDTO(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -9,8 +9,6 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import no.nav.k9.oppgave.OppgaveBekreftelse
-import no.nav.k9.oppgave.bekreftelse.Bekreftelse
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.ArbeidOgFrilansRegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.BekreftelseDTO
@@ -83,13 +81,10 @@ class OppgaveDAO(
             løstDato = løstDato
         )
 
-        fun OppgaveBekreftelse.tilDTO(): BekreftelseDTO {
-            val bekreftelse = getBekreftelse<Bekreftelse>()
-            return BekreftelseDTO(
-                harGodtattEndringen = bekreftelse.harBrukerGodtattEndringen(),
-                uttalelseFraBruker = bekreftelse.uttalelseFraBruker,
-            )
-        }
+        fun OppgaveBekreftelse.tilDTO(): BekreftelseDTO = BekreftelseDTO(
+            harGodtattEndringen = harGodtattEndringen,
+            uttalelseFraBruker = uttalelseFraBruker,
+        )
 
         fun OppgavetypeDataDAO.tilDTO(): OppgavetypeDataDTO = when (this) {
             is EndretProgramperiodeOppgavetypeDataDAO -> EndretProgramperiodeDataDTO(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/varsler/MineSiderVarselService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/varsler/MineSiderVarselService.kt
@@ -1,6 +1,7 @@
 package no.nav.ung.deltakelseopplyser.domene.varsler
 
 import no.nav.tms.varsel.action.EksternKanal
+import no.nav.tms.varsel.action.Produsent
 import no.nav.tms.varsel.action.Sensitivitet
 import no.nav.tms.varsel.action.Tekst
 import no.nav.tms.varsel.action.Varseltype
@@ -14,6 +15,10 @@ import org.springframework.stereotype.Service
 class MineSiderVarselService(
     @Value("\${topic.producer.min-side-varsel.navn}") private val minSideVarselTopic: String,
     private val kafkaTemplate: KafkaTemplate<String, String>,
+    @Value("\${NAIS_CLUSTER_NAME}") private val cluster: String,
+    @Value("\${NAIS_NAMESPACE}") private val namespace: String,
+    @Value("\${NAIS_APP_NAME}") private val appName: String,
+
 ) {
     private companion object {
         private val logger = LoggerFactory.getLogger(MineSiderVarselService::class.java)
@@ -80,6 +85,8 @@ class MineSiderVarselService(
             eksternVarsling {
                 preferertKanal = EksternKanal.SMS
             }
+
+            produsent = produsent()
         }
 
         kafkaTemplate.send(minSideVarselTopic, oppgaveId, opprett)
@@ -107,6 +114,7 @@ class MineSiderVarselService(
          */
         val inaktiver = VarselActionBuilder.inaktiver {
             varselId = oppgaveId
+            produsent = produsent()
         }
 
         kafkaTemplate.send(minSideVarselTopic, oppgaveId, inaktiver)
@@ -121,4 +129,10 @@ class MineSiderVarselService(
                 }
             }
     }
+
+    private fun produsent() = Produsent(
+        cluster = cluster,
+        namespace = namespace,
+        appnavn = appName,
+    )
 }

--- a/app/src/main/resources/db/migration/V9__oppgave_bekreftelse_kolonne.sql
+++ b/app/src/main/resources/db/migration/V9__oppgave_bekreftelse_kolonne.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oppgave
+    ADD COLUMN oppgave_bekreftelse JSONB NULL;

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
@@ -1,0 +1,306 @@
+package no.nav.ung.deltakelseopplyser.domene.oppgave
+
+import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.every
+import io.mockk.verify
+import no.nav.k9.oppgave.OppgaveBekreftelse
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse
+import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretProgramperiodeBekreftelse
+import no.nav.k9.søknad.felles.Kildesystem
+import no.nav.k9.søknad.felles.Versjon
+import no.nav.k9.søknad.felles.personopplysninger.Søker
+import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer
+import no.nav.k9.søknad.felles.type.Periode
+import no.nav.k9.søknad.felles.type.SøknadId
+import no.nav.pdl.generated.enums.IdentGruppe
+import no.nav.pdl.generated.hentident.IdentInformasjon
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import no.nav.ung.deltakelseopplyser.AbstractIntegrationTest
+import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerRepository
+import no.nav.ung.deltakelseopplyser.domene.oppgave.kafka.UngdomsytelseOppgavebekreftelse
+import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
+import no.nav.ung.deltakelseopplyser.domene.register.ungsak.OppgaveUngSakController
+import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
+import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.EndretProgamperiodeOppgaveDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.ProgramperiodeDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektArbeidOgFrilansDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektOppgaveDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektYtelseDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.util.*
+
+@EnableMockOAuth2Server
+@ExtendWith(SpringExtension::class)
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class OppgaveServiceTest : AbstractIntegrationTest() {
+
+    @Autowired
+    lateinit var oppgaveService: OppgaveService
+
+    @Autowired
+    lateinit var deltakelseService: UngdomsprogramregisterService
+
+    @Autowired
+    lateinit var deltakelseRepository: UngdomsprogramDeltakelseRepository
+
+    @Autowired
+    lateinit var deltakerRepository: DeltakerRepository
+
+    @Autowired
+    lateinit var oppgaveUngSakController: OppgaveUngSakController
+
+    @SpykBean
+    lateinit var mineSiderVarselService: MineSiderVarselService
+
+    @MockkBean
+    lateinit var pdlService: PdlService
+
+    private companion object {
+        const val deltakerIdent = "12345678901"
+        const val deltakerAktørId = "10987654321"
+
+    }
+
+    override val consumerGroupPrefix: String
+        get() = "oppgave-service-test"
+    override val consumerGroupTopics: List<String>
+        get() = listOf()
+
+    @BeforeEach
+    fun setUpEach() {
+        deltakelseRepository.deleteAll()
+        deltakerRepository.deleteAll()
+
+        every { pdlService.hentAktørIder(any(), any()) } returns listOf(
+            IdentInformasjon(
+                ident = deltakerAktørId,
+                historisk = false,
+                gruppe = IdentGruppe.AKTORID
+            )
+        )
+
+        every { pdlService.hentFolkeregisteridenter(any()) } returns listOf(
+            IdentInformasjon(
+                ident = deltakerIdent,
+                historisk = false,
+                gruppe = IdentGruppe.FOLKEREGISTERIDENT
+            )
+        )
+    }
+
+    @Test
+    fun `Gitt det mottas bekreftelse på endret periode oppgave, forvent at den lagres og hentes opp igjen`() {
+        val orginalStartdato: LocalDate = LocalDate.now()
+        meldInnIProgrammet(deltakerIdent, orginalStartdato)
+
+        endreProgramperiode(
+            deltakerIdent = deltakerIdent,
+            originalPeriode = ProgramperiodeDTO(
+                fomDato = orginalStartdato,
+                tomDato = null
+            ),
+            nyPeriode = ProgramperiodeDTO(
+                fomDato = orginalStartdato.plusDays(3),
+                tomDato = null
+            )
+        )
+
+        val oppgaver = deltakelseService.hentAlleForDeltaker(deltakerIdent).first().oppgaver
+        assertThat(oppgaver).hasSize(1)
+        val oppgaveReferanse = oppgaver.first().oppgaveReferanse
+
+        oppgaveService.håndterMottattOppgavebekreftelse(
+            oppgaveBekreftelse(
+                oppgaveReferanse,
+                deltakerIdent,
+                EndretProgramperiodeBekreftelse(
+                    oppgaveReferanse,
+                    Periode(LocalDate.now(), LocalDate.now().plusDays(30)),
+                    false
+                ).medUttalelseFraBruker("Det er feil med datoene")
+            )
+        )
+
+        val oppdatertDeltakelse = deltakelseService.hentAlleForDeltaker(deltakerIdent).first()
+        val oppgave = oppdatertDeltakelse.oppgaver.first()
+        assertThat(oppgave.status).isEqualTo(OppgaveStatus.LØST)
+        assertThat(oppgave.oppgaveReferanse).isEqualTo(oppgaveReferanse)
+        assertThat(oppgave.oppgavetypeData).isInstanceOf(EndretProgramperiodeDataDTO::class.java)
+        assertThat(oppgave.bekreftelse).isNotNull
+        assertThat(oppgave.bekreftelse?.harGodtattEndringen).isFalse()
+        assertThat(oppgave.bekreftelse?.uttalelseFraBruker).isEqualTo("Det er feil med datoene")
+
+        verify(exactly = 1) { mineSiderVarselService.deaktiverOppgave(oppgaveReferanse.toString()) }
+    }
+
+    @Test
+    fun `Gitt det mottas bekreftelse på avvik på registerinntekt oppgave, forvent at den lagres og hentes opp igjen`() {
+        val orginalStartdato: LocalDate = LocalDate.now()
+        meldInnIProgrammet(deltakerIdent, orginalStartdato)
+
+        kontrollerAvvikPåInntektIRegister(
+            deltakerIdent = deltakerIdent,
+            periode = ProgramperiodeDTO(
+                fomDato = orginalStartdato,
+                tomDato = orginalStartdato.plusWeeks(4)
+            )
+        )
+
+        val oppgaver = deltakelseService.hentAlleForDeltaker(deltakerIdent).first().oppgaver
+        assertThat(oppgaver).hasSize(1)
+        val oppgaveReferanse = oppgaver.first().oppgaveReferanse
+
+        oppgaveService.håndterMottattOppgavebekreftelse(
+            oppgaveBekreftelse(
+                oppgaveReferanse,
+                deltakerIdent,
+                InntektBekreftelse(
+                    oppgaveReferanse,
+                    false,
+                    "Det er feil inntekt i registeret"
+                )
+            )
+        )
+
+        val oppdatertDeltakelse = deltakelseService.hentAlleForDeltaker(deltakerIdent).first()
+        val oppgave = oppdatertDeltakelse.oppgaver.first()
+        assertThat(oppgave.status).isEqualTo(OppgaveStatus.LØST)
+        assertThat(oppgave.oppgaveReferanse).isEqualTo(oppgaveReferanse)
+        assertThat(oppgave.oppgavetypeData).isInstanceOf(KontrollerRegisterinntektOppgavetypeDataDTO::class.java)
+        assertThat(oppgave.bekreftelse).isNotNull
+        assertThat(oppgave.bekreftelse?.harGodtattEndringen).isFalse()
+        assertThat(oppgave.bekreftelse?.uttalelseFraBruker).isEqualTo("Det er feil inntekt i registeret")
+
+        verify(exactly = 1) { mineSiderVarselService.deaktiverOppgave(oppgaveReferanse.toString()) }
+
+    }
+
+    @Test
+    fun `Gitt det mottas feil type bekreftelse på oppgave, forvent at kastes feil`() {
+        val orginalStartdato: LocalDate = LocalDate.now()
+        meldInnIProgrammet(deltakerIdent, orginalStartdato)
+
+        endreProgramperiode(
+            deltakerIdent = deltakerIdent,
+            originalPeriode = ProgramperiodeDTO(
+                fomDato = orginalStartdato,
+                tomDato = null
+            ),
+            nyPeriode = ProgramperiodeDTO(
+                fomDato = orginalStartdato.plusDays(3),
+                tomDato = null
+            )
+        )
+
+        val oppgaver = deltakelseService.hentAlleForDeltaker(deltakerIdent).first().oppgaver
+        assertThat(oppgaver).hasSize(1)
+        val oppgaveReferanse = oppgaver.first().oppgaveReferanse
+
+        assertThrows<IllegalStateException> {
+            oppgaveService.håndterMottattOppgavebekreftelse(
+                oppgaveBekreftelse(
+                    oppgaveReferanse,
+                    deltakerIdent,
+                    InntektBekreftelse(
+                        oppgaveReferanse,
+                        false,
+                        "Det er feil inntekt"
+                    )
+                )
+            )
+        }
+
+        verify(exactly = 0) { mineSiderVarselService.deaktiverOppgave(oppgaveReferanse.toString()) }
+    }
+
+    private fun endreProgramperiode(
+        deltakerIdent: String,
+        originalPeriode: ProgramperiodeDTO,
+        nyPeriode: ProgramperiodeDTO,
+    ) {
+        oppgaveUngSakController.opprettOppgaveForEndretProgramperiode(
+            endretProgramperiodeOppgaveDTO = EndretProgamperiodeOppgaveDTO(
+                deltakerIdent = deltakerIdent,
+                oppgaveReferanse = UUID.randomUUID(),
+                frist = LocalDateTime.now().plusDays(14),
+                programperiode = nyPeriode,
+                forrigeProgramperiode = originalPeriode,
+            )
+        )
+    }
+
+    private fun kontrollerAvvikPåInntektIRegister(
+        deltakerIdent: String,
+        periode: ProgramperiodeDTO,
+    ) {
+        oppgaveUngSakController.opprettOppgaveForKontrollAvRegisterinntekt(
+            opprettOppgaveDto = RegisterInntektOppgaveDTO(
+                deltakerIdent = deltakerIdent,
+                referanse = UUID.randomUUID(),
+                frist = LocalDateTime.now().plusDays(14),
+                fomDato = periode.fomDato,
+                tomDato = periode.tomDato!!,
+                registerInntekter = RegisterInntektDTO(
+                    registerinntekterForArbeidOgFrilans = listOf(
+                        RegisterInntektArbeidOgFrilansDTO(1000, "123"),
+                        RegisterInntektArbeidOgFrilansDTO(2000, "321"),
+                    ),
+                    registerinntekterForYtelse = listOf(
+                        RegisterInntektYtelseDTO(1000, "Sykepenger"),
+                        RegisterInntektYtelseDTO(2000, "Pleiepenger"),
+                    )
+                )
+            )
+        )
+    }
+
+    fun oppgaveBekreftelse(
+        oppgaveReferanse: UUID,
+        deltakerIdent: String,
+        bekreftelse: Bekreftelse,
+    ): UngdomsytelseOppgavebekreftelse = UngdomsytelseOppgavebekreftelse(
+        oppgaveBekreftelse = OppgaveBekreftelse()
+            .medSøknadId(SøknadId(oppgaveReferanse.toString()))
+            .medVersjon(Versjon("1.0.0"))
+            .medMottattDato(ZonedDateTime.now())
+            .medKildesystem(Kildesystem.SØKNADSDIALOG)
+            .medSøker(Søker(NorskIdentitetsnummer.of(deltakerIdent)))
+            .medBekreftelse(bekreftelse),
+        journalpostId = "123456",
+    )
+
+
+    private fun meldInnIProgrammet(søkerIdent: String, deltakelseStart: LocalDate): DeltakelseOpplysningDTO {
+        return deltakelseService.leggTilIProgram(
+            deltakelseOpplysningDTO = DeltakelseOpplysningDTO(
+                deltaker = DeltakerDTO(deltakerIdent = søkerIdent),
+                harSøkt = false,
+                fraOgMed = deltakelseStart,
+                tilOgMed = null,
+                oppgaver = listOf()
+            )
+        )
+    }
+}

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -2,7 +2,9 @@ ABAC_ENABLED: false
 UNGDOMSYTELSE_DELTAKER_BASE_URL: http://localhost:8080/ungdomsytelse-deltaker # placeholder
 AZURE_APP_PRE_AUTHORIZED_APPS: \"[{"name":":ung-sak", "clientId":"vtp"}]\"
 
-
+NAIS_CLUSTER_NAME: dev-gcp
+NAIS_NAMESPACE: k9saksbehandling
+NAIS_APP_NAME: ung-deltakelse-opplyser
 
 spring:
   datasource:

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/BekreftelseDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/BekreftelseDTO.kt
@@ -1,0 +1,8 @@
+package no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class BekreftelseDTO(
+    @JsonProperty("harGodtattEndringen") val harGodtattEndringen: Boolean,
+    @JsonProperty("uttalelseFraBruker") val uttalelseFraBruker: String? = null,
+)

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
@@ -8,6 +8,7 @@ data class OppgaveDTO(
     @JsonProperty("oppgaveReferanse") val oppgaveReferanse: UUID,
     @JsonProperty("oppgavetype") val oppgavetype: Oppgavetype,
     @JsonProperty("oppgavetypeData") val oppgavetypeData: OppgavetypeDataDTO,
+    @JsonProperty("bekreftelse") val bekreftelse: BekreftelseDTO?,
     @JsonProperty("status") val status: OppgaveStatus,
     @JsonProperty("opprettetDato") val opprettetDato: ZonedDateTime,
     @JsonProperty("løstDato") val løstDato: ZonedDateTime?,


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det er ønskelig å presentere til deltaker det hen har bekreftet av opplysninger på oppgave.

### **Løsning**
- Utvider `OppgaveDAO` med nytt kolonne for å lagre `bekreftelse`.
- Ved mottatt bekreftelse på oppgave, valideres og settes bekreftelse på oppgaven, og lagres ned.
- Utvider `OppgaveDTO` med `BekreftelseDTO` som inneholder uttalelse fra deltaker.

### **Andre endringer**
- Konfigurerer `produsent` på `MineSiderVarselService` eksplisitt lik at det er klart at det settes.