### PR TITLE
Begrenser innmelding til dato for programstart.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
@@ -2,7 +2,6 @@ package no.nav.ung.deltakelseopplyser.domene.deltaker
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.pdl.generated.hentperson.Navn
-import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.util.*
 
@@ -11,27 +10,13 @@ data class DeltakerPersonalia(
     val deltakerIdent: String,
     val navn: Navn,
     val fødselsdato: LocalDate,
+    val programOppstartdato: LocalDate? = null,
 ) {
-    companion object {
-        const val PROGRAM_OPPSTART_DATO_PROPERTY = "PROGRAM_OPPSTART_DATO"
-    }
-
-    private fun programOppstartDato(): LocalDate? =
-        System
-            .getProperty(PROGRAM_OPPSTART_DATO_PROPERTY)
-            .also {
-                if (it != null) {
-                    LoggerFactory.getLogger(DeltakerPersonalia::class.java).info("Bruker system-egenskap $PROGRAM_OPPSTART_DATO_PROPERTY med verdi $it")
-                }
-            }
-            .takeIf { it?.isNotBlank() == true }
-            ?.let(LocalDate::parse)
-
     @get:JsonProperty("førsteMuligeInnmeldingsdato")
     val førsteMuligeInnmeldingsdato: LocalDate
         get() {
             val aldersDato = fødselsdato.plusYears(18).plusMonths(1)
-            return programOppstartDato()
+            return programOppstartdato
                 ?.let { maxOf(aldersDato, it) }
                 ?: aldersDato
         }
@@ -40,7 +25,7 @@ data class DeltakerPersonalia(
     val sisteMuligeInnmeldingsdato: LocalDate
         get() {
             val aldersSiste = fødselsdato.plusYears(29)
-            return programOppstartDato()
+            return programOppstartdato
                 ?.let { maxOf(aldersSiste, it) }
                 ?: aldersSiste
         }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
@@ -24,9 +24,9 @@ data class DeltakerPersonalia(
     @get:JsonProperty("sisteMuligeInnmeldingsdato")
     val sisteMuligeInnmeldingsdato: LocalDate
         get() {
-            val aldersSiste = fødselsdato.plusYears(29)
+            val aldersDatoSiste = fødselsdato.plusYears(29)
             return programOppstartdato
-                ?.let { maxOf(aldersSiste, it) }
-                ?: aldersSiste
+                ?.let { maxOf(aldersDatoSiste, it) }
+                ?: aldersDatoSiste
         }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
@@ -1,0 +1,41 @@
+package no.nav.ung.deltakelseopplyser.domene.deltaker
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import no.nav.pdl.generated.hentperson.Navn
+import java.time.LocalDate
+import java.util.*
+
+data class DeltakerPersonalia(
+    val id: UUID? = null,
+    val deltakerIdent: String,
+    val navn: Navn,
+    val fødselsdato: LocalDate,
+) {
+    companion object {
+        const val PROGRAM_OPPSTART_DATO_PROPERTY = "PROGRAM_OPPSTART_DATO"
+    }
+
+    private fun programOppstartDato(): LocalDate? =
+        System
+            .getProperty(PROGRAM_OPPSTART_DATO_PROPERTY)
+            .takeIf { it?.isNotBlank() == true }
+            ?.let(LocalDate::parse)
+
+    @get:JsonProperty("førsteMuligeInnmeldingsdato")
+    val førsteMuligeInnmeldingsdato: LocalDate
+        get() {
+            val aldersDato = fødselsdato.plusYears(18).plusMonths(1)
+            return programOppstartDato()
+                ?.let { maxOf(aldersDato, it) }
+                ?: aldersDato
+        }
+
+    @get:JsonProperty("sisteMuligeInnmeldingsdato")
+    val sisteMuligeInnmeldingsdato: LocalDate
+        get() {
+            val aldersSiste = fødselsdato.plusYears(29)
+            return programOppstartDato()
+                ?.let { maxOf(aldersSiste, it) }
+                ?: aldersSiste
+        }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
@@ -2,6 +2,7 @@ package no.nav.ung.deltakelseopplyser.domene.deltaker
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.pdl.generated.hentperson.Navn
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.util.*
 
@@ -18,6 +19,11 @@ data class DeltakerPersonalia(
     private fun programOppstartDato(): LocalDate? =
         System
             .getProperty(PROGRAM_OPPSTART_DATO_PROPERTY)
+            .also {
+                if (it != null) {
+                    LoggerFactory.getLogger(DeltakerPersonalia::class.java).info("Bruker system-egenskap $PROGRAM_OPPSTART_DATO_PROPERTY med verdi $it")
+                }
+            }
             .takeIf { it?.isNotBlank() == true }
             ?.let(LocalDate::parse)
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
@@ -10,7 +10,7 @@ data class DeltakerPersonalia(
     val deltakerIdent: String,
     val navn: Navn,
     val fødselsdato: LocalDate,
-    val programOppstartdato: LocalDate? = null,
+    private val programOppstartdato: LocalDate? = null,
 ) {
     @get:JsonProperty("førsteMuligeInnmeldingsdato")
     val førsteMuligeInnmeldingsdato: LocalDate

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -1,8 +1,6 @@
 package no.nav.ung.deltakelseopplyser.domene.deltaker
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.pdl.generated.hentperson.Foedselsdato
-import no.nav.pdl.generated.hentperson.Navn
 import no.nav.pdl.generated.hentperson.Person
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
@@ -11,6 +9,7 @@ import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.KontonummerDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 import org.springframework.stereotype.Service
@@ -23,6 +22,7 @@ class DeltakerService(
     private val deltakerRepository: DeltakerRepository,
     private val pdlService: PdlService,
     private val kontoregisterService: KontoregisterService,
+    @Value("\${PROGRAM_OPPSTART_DATO}") private val programOppstartdato: String? = null,
 ) {
 
     companion object {
@@ -109,7 +109,8 @@ class DeltakerService(
             id = deltakerDAO?.id,
             deltakerIdent = deltakerDAO.deltakerIdent,
             navn = pdlPerson.navn.first(),
-            fødselsdato = pdlPerson.foedselsdato.first().toLocalDate()
+            fødselsdato = pdlPerson.foedselsdato.first().toLocalDate(),
+            programOppstartdato = programOppstartdato?.let { LocalDate.parse(it) }
         )
     }
 
@@ -145,7 +146,8 @@ class DeltakerService(
             id = deltakerDAO?.id,
             deltakerIdent = deltakerIdent,
             navn = PdlPerson.navn.first(),
-            fødselsdato = PdlPerson.foedselsdato.first().toLocalDate()
+            fødselsdato = PdlPerson.foedselsdato.first().toLocalDate(),
+            programOppstartdato = programOppstartdato?.let { LocalDate.parse(it) }
         )
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -39,7 +39,7 @@ class DeltakerService(
         }
     }
 
-    fun hentDeltakerInfo(deltakerId: UUID? = null, deltakerIdent: String? = null): DeltakerPersonlia? {
+    fun hentDeltakerInfo(deltakerId: UUID? = null, deltakerIdent: String? = null): DeltakerPersonalia? {
         return when {
             deltakerId != null -> hentDeltakerInfoMedId(deltakerId)
             deltakerIdent != null -> hentDeltakerInfoMedIdent(deltakerIdent)
@@ -91,7 +91,7 @@ class DeltakerService(
         return deltakerRepository.finnDeltakerGittOppgaveReferanse(oppgaveReferanse)
     }
 
-    private fun hentDeltakerInfoMedId(id: UUID): DeltakerPersonlia {
+    private fun hentDeltakerInfoMedId(id: UUID): DeltakerPersonalia {
         val deltakerDAO = deltakerRepository.findById(id).orElseThrow {
             ErrorResponseException(
                 HttpStatus.NOT_FOUND,
@@ -105,7 +105,7 @@ class DeltakerService(
 
         val pdlPerson = hentPdlPerson(deltakerDAO.deltakerIdent)
 
-        return DeltakerPersonlia(
+        return DeltakerPersonalia(
             id = deltakerDAO?.id,
             deltakerIdent = deltakerDAO.deltakerIdent,
             navn = pdlPerson.navn.first(),
@@ -136,12 +136,12 @@ class DeltakerService(
         return deltakerRepository.findByDeltakerIdentIn(identer)
     }
 
-    private fun hentDeltakerInfoMedIdent(deltakerIdent: String): DeltakerPersonlia {
+    private fun hentDeltakerInfoMedIdent(deltakerIdent: String): DeltakerPersonalia {
         val deltakerDAO = deltakerRepository.findByDeltakerIdent(deltakerIdent)
 
         val PdlPerson = hentPdlPerson(deltakerDAO?.deltakerIdent ?: deltakerIdent)
 
-        return DeltakerPersonlia(
+        return DeltakerPersonalia(
             id = deltakerDAO?.id,
             deltakerIdent = deltakerIdent,
             navn = PdlPerson.navn.first(),
@@ -155,20 +155,5 @@ class DeltakerService(
 
     fun hentKontonummer(): KontonummerDTO {
         return kontoregisterService.hentAktivKonto()
-    }
-
-    data class DeltakerPersonlia(
-        val id: UUID? = null,
-        val deltakerIdent: String,
-        val navn: Navn,
-        val fødselsdato: LocalDate,
-    ) {
-        @get:JsonProperty("førsteMuligeInnmeldingsdato")
-        val førsteMuligeInnmeldingsdato: LocalDate
-            get() = fødselsdato.plusYears(18).plusMonths(1)
-
-        @get:JsonProperty("sisteMuligeInnmeldingsdato")
-        val sisteMuligeInnmeldingsdato: LocalDate
-            get() = fødselsdato.plusYears(29)
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramDeltakerInfoVeilederController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramDeltakerInfoVeilederController.kt
@@ -9,6 +9,7 @@ import no.nav.sif.abac.kontrakt.person.PersonIdent
 import no.nav.ung.deltakelseopplyser.audit.SporingsloggService
 import no.nav.ung.deltakelseopplyser.config.Issuers
 import no.nav.ung.deltakelseopplyser.config.Issuers.TOKEN_X
+import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerPersonalia
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
@@ -40,7 +41,7 @@ class UngdomsprogramDeltakerInfoVeilederController(
     @PostMapping("/deltaker", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Hent personalia for en deltaker")
     @ResponseStatus(HttpStatus.OK)
-    fun hentDeltakerInfoGittDeltaker(@RequestBody deltakerDTO: DeltakerDTO): DeltakerService.DeltakerPersonlia? {
+    fun hentDeltakerInfoGittDeltaker(@RequestBody deltakerDTO: DeltakerDTO): DeltakerPersonalia? {
         tilgangskontrollService.krevAnsattTilgang(READ, listOf(PersonIdent.fra(deltakerDTO.deltakerIdent)))
         return deltakerService.hentDeltakerInfo(deltakerIdent = deltakerDTO.deltakerIdent)
             .also {
@@ -55,7 +56,7 @@ class UngdomsprogramDeltakerInfoVeilederController(
     @GetMapping("/deltaker/{id}", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Hent personlia for en deltaker gitt en UUID")
     @ResponseStatus(HttpStatus.OK)
-    fun hentDeltakerInfoGittDeltakerId(@PathVariable id: UUID): DeltakerService.DeltakerPersonlia? {
+    fun hentDeltakerInfoGittDeltakerId(@PathVariable id: UUID): DeltakerPersonalia? {
         val deltakerInfo = deltakerService.hentDeltakerInfo(deltakerId = id) ?: return null
         val personIdent = PersonIdent.fra(deltakerInfo.deltakerIdent)
         tilgangskontrollService.krevAnsattTilgang(READ, listOf(personIdent))

--- a/app/src/main/resources/application-dev-gcp.yml
+++ b/app/src/main/resources/application-dev-gcp.yml
@@ -28,3 +28,5 @@ spring:
       key-store-location: file:${KAFKA_KEYSTORE_PATH}
       key-store-password: ${KAFKA_CREDSTORE_PASSWORD}
       key-store-type: PKCS12
+
+PROGRAM_OPPSTART_DATO: 2025-01-01

--- a/app/src/main/resources/application-prod-gcp.yml
+++ b/app/src/main/resources/application-prod-gcp.yml
@@ -19,3 +19,5 @@ spring:
       key-store-location: file:${KAFKA_KEYSTORE_PATH}
       key-store-password: ${KAFKA_CREDSTORE_PASSWORD}
       key-store-type: PKCS12
+
+PROGRAM_OPPSTART_DATO: 2025-08-01

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+PROGRAM_OPPSTART_DATO: 2025-08-01 # Husk å flytte denne til prod-gcp profilen slik at den kun er gjeldene for prod.
+
 spring:
   application:
     name: # Settes i nais/<cluster>.json

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,5 +1,3 @@
-PROGRAM_OPPSTART_DATO: 2025-08-01 # Husk å flytte denne til prod-gcp profilen slik at den kun er gjeldene for prod.
-
 spring:
   application:
     name: # Settes i nais/<cluster>.json

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonliaTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonliaTest.kt
@@ -1,82 +1,76 @@
 package no.nav.ung.deltakelseopplyser.domene.deltaker
 
 import no.nav.pdl.generated.hentperson.Navn
-import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerPersonalia.Companion.PROGRAM_OPPSTART_DATO_PROPERTY
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.util.*
 
 internal class DeltakerPersonaliaTest {
 
-    private fun lagDeltakerPersonalia(fødselsdato: LocalDate) = DeltakerPersonalia(
+    private fun lagDeltakerPersonalia(fødselsdato: LocalDate, programOppstartdato: LocalDate?) = DeltakerPersonalia(
         id = UUID.randomUUID(),
         deltakerIdent = "12345678901",
         navn = Navn("Ola", null, "Nordmann"),
-        fødselsdato = fødselsdato
+        fødselsdato = fødselsdato,
+        programOppstartdato = programOppstartdato
     )
 
-    @BeforeEach
-    fun clearSystemProperty() {
-        System.clearProperty(PROGRAM_OPPSTART_DATO_PROPERTY)
-    }
-
     @Test
-    fun `uten system-egenskap skal førsteMuligeInnmeldingsdato være 18 år + 1 måned etter fødselsdato`() {
+    fun `uten programOppstartdato skal førsteMuligeInnmeldingsdato være 18 år + 1 måned etter fødselsdato`() {
         val fødselsdato = LocalDate.of(2000, 1, 15)
         assertEquals(
             LocalDate.of(2018, 2, 15),
-            lagDeltakerPersonalia(fødselsdato).førsteMuligeInnmeldingsdato
+            lagDeltakerPersonalia(fødselsdato, null).førsteMuligeInnmeldingsdato
         )
     }
 
     @Test
-    fun `med system-egenskap senere enn aldersdato skal førsteMuligeInnmeldingsdato override`() {
+    fun `med programOppstartdato senere enn aldersdato skal førsteMuligeInnmeldingsdato override`() {
         val fødselsdato = LocalDate.of(2000, 1, 15)
-        System.setProperty(PROGRAM_OPPSTART_DATO_PROPERTY, "2025-08-01")
+        val programOppstartdato = LocalDate.of(2025, 8, 1)
         assertEquals(
             LocalDate.of(2025, 8, 1),
-            lagDeltakerPersonalia(fødselsdato).førsteMuligeInnmeldingsdato
+            lagDeltakerPersonalia(fødselsdato, programOppstartdato).førsteMuligeInnmeldingsdato
         )
     }
 
     @Test
-    fun `med system-egenskap tidligere enn aldersdato skal aldersdato vinne for førsteMuligeInnmelding`() {
+    fun `med programOppstartdato tidligere enn aldersdato skal aldersdato vinne for førsteMuligeInnmelding`() {
         val fødselsdato = LocalDate.of(2000, 1, 15)
-        System.setProperty(PROGRAM_OPPSTART_DATO_PROPERTY, "2017-01-01")
+        val programOppstartdato = LocalDate.of(2017, 1, 1)
         assertEquals(
             LocalDate.of(2018, 2, 15),
-            lagDeltakerPersonalia(fødselsdato).førsteMuligeInnmeldingsdato
+            lagDeltakerPersonalia(fødselsdato, programOppstartdato).førsteMuligeInnmeldingsdato
         )
     }
 
     @Test
-    fun `uten system-egenskap skal sisteMuligeInnmeldingsdato være fødselsdato + 29 år`() {
+    fun `uten programOppstartdato skal sisteMuligeInnmeldingsdato være fødselsdato + 29 år`() {
         val fødselsdato = LocalDate.of(1996, 5, 10)
         assertEquals(
             LocalDate.of(2025, 5, 10),
-            lagDeltakerPersonalia(fødselsdato).sisteMuligeInnmeldingsdato
+            lagDeltakerPersonalia(fødselsdato, null).sisteMuligeInnmeldingsdato
         )
     }
 
     @Test
-    fun `med system-egenskap senere enn sisteMuligeInnmeldingsdato skal override`() {
+    fun `med programOppstartdato senere enn sisteMuligeInnmeldingsdato skal override`() {
         val fødselsdato = LocalDate.of(1996, 5, 10)
-        System.setProperty(PROGRAM_OPPSTART_DATO_PROPERTY, "2025-08-01")
+        val programOppstartdato = LocalDate.of(2025, 8, 1)
         assertEquals(
             LocalDate.of(2025, 8, 1),
-            lagDeltakerPersonalia(fødselsdato).sisteMuligeInnmeldingsdato
+            lagDeltakerPersonalia(fødselsdato, programOppstartdato).sisteMuligeInnmeldingsdato
         )
     }
 
     @Test
-    fun `med system-egenskap tidligere enn sisteMuligeInnmeldingsdato skal alder vinne`() {
+    fun `med programOppstartdato tidligere enn sisteMuligeInnmeldingsdato skal alder vinne`() {
         val fødselsdato = LocalDate.of(1996, 5, 10)
-        System.setProperty(PROGRAM_OPPSTART_DATO_PROPERTY, "2025-01-01")
+        val programOppstartdato = LocalDate.of(2025, 1, 1)
         assertEquals(
             LocalDate.of(2025, 5, 10),
-            lagDeltakerPersonalia(fødselsdato).sisteMuligeInnmeldingsdato
+            lagDeltakerPersonalia(fødselsdato, programOppstartdato).sisteMuligeInnmeldingsdato
         )
     }
 }

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonliaTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonliaTest.kt
@@ -1,0 +1,82 @@
+package no.nav.ung.deltakelseopplyser.domene.deltaker
+
+import no.nav.pdl.generated.hentperson.Navn
+import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerPersonalia.Companion.PROGRAM_OPPSTART_DATO_PROPERTY
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.*
+
+internal class DeltakerPersonaliaTest {
+
+    private fun lagDeltakerPersonalia(fødselsdato: LocalDate) = DeltakerPersonalia(
+        id = UUID.randomUUID(),
+        deltakerIdent = "12345678901",
+        navn = Navn("Ola", null, "Nordmann"),
+        fødselsdato = fødselsdato
+    )
+
+    @BeforeEach
+    fun clearSystemProperty() {
+        System.clearProperty(PROGRAM_OPPSTART_DATO_PROPERTY)
+    }
+
+    @Test
+    fun `uten system-egenskap skal førsteMuligeInnmeldingsdato være 18 år + 1 måned etter fødselsdato`() {
+        val fødselsdato = LocalDate.of(2000, 1, 15)
+        assertEquals(
+            LocalDate.of(2018, 2, 15),
+            lagDeltakerPersonalia(fødselsdato).førsteMuligeInnmeldingsdato
+        )
+    }
+
+    @Test
+    fun `med system-egenskap senere enn aldersdato skal førsteMuligeInnmeldingsdato override`() {
+        val fødselsdato = LocalDate.of(2000, 1, 15)
+        System.setProperty(PROGRAM_OPPSTART_DATO_PROPERTY, "2025-08-01")
+        assertEquals(
+            LocalDate.of(2025, 8, 1),
+            lagDeltakerPersonalia(fødselsdato).førsteMuligeInnmeldingsdato
+        )
+    }
+
+    @Test
+    fun `med system-egenskap tidligere enn aldersdato skal aldersdato vinne for førsteMuligeInnmelding`() {
+        val fødselsdato = LocalDate.of(2000, 1, 15)
+        System.setProperty(PROGRAM_OPPSTART_DATO_PROPERTY, "2017-01-01")
+        assertEquals(
+            LocalDate.of(2018, 2, 15),
+            lagDeltakerPersonalia(fødselsdato).førsteMuligeInnmeldingsdato
+        )
+    }
+
+    @Test
+    fun `uten system-egenskap skal sisteMuligeInnmeldingsdato være fødselsdato + 29 år`() {
+        val fødselsdato = LocalDate.of(1996, 5, 10)
+        assertEquals(
+            LocalDate.of(2025, 5, 10),
+            lagDeltakerPersonalia(fødselsdato).sisteMuligeInnmeldingsdato
+        )
+    }
+
+    @Test
+    fun `med system-egenskap senere enn sisteMuligeInnmeldingsdato skal override`() {
+        val fødselsdato = LocalDate.of(1996, 5, 10)
+        System.setProperty(PROGRAM_OPPSTART_DATO_PROPERTY, "2025-08-01")
+        assertEquals(
+            LocalDate.of(2025, 8, 1),
+            lagDeltakerPersonalia(fødselsdato).sisteMuligeInnmeldingsdato
+        )
+    }
+
+    @Test
+    fun `med system-egenskap tidligere enn sisteMuligeInnmeldingsdato skal alder vinne`() {
+        val fødselsdato = LocalDate.of(1996, 5, 10)
+        System.setProperty(PROGRAM_OPPSTART_DATO_PROPERTY, "2025-01-01")
+        assertEquals(
+            LocalDate.of(2025, 5, 10),
+            lagDeltakerPersonalia(fødselsdato).sisteMuligeInnmeldingsdato
+        )
+    }
+}

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -6,6 +6,8 @@ NAIS_CLUSTER_NAME: dev-gcp
 NAIS_NAMESPACE: k9saksbehandling
 NAIS_APP_NAME: ung-deltakelse-opplyser
 
+PROGRAM_OPPSTART_DATO: 2024-01-01
+
 spring:
   datasource:
     url: jdbc:tc:postgresql:16:///?TC_INITSCRIPT=file:src/test/resources/db/init.sql


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det skal være begrensning på når en kan melde inn deltaker som baserer seg på når programmet er lansert. For testing sin del må dette være en annen dato i Q enn i prod.

### **Løsning**
Definerer og bruker miljøvariabel `PROGRAM_OPPSTART_DATO` for å sette dato for programstart.
Dersom denne er satt, skal første og siste innmeldingsdato ta hensyn til denne datoen. Det betyr at hvis deltaker har fylt 18 og egentlig kvalifiserer til innmelding, men programmet ikke har startet enda, skal datoen settes til dette.

For dev-gcp settes `PROGRAM_OPPSTART_DATO` til `2025-01-01`

### **Andre endringer**
Flytter `DeltakerPersonalia` ut til egen fil.

### **Skjermbilder** (hvis relevant)

#### Skjermbilde av resultatet i Q der programstart er satt `2025-08-01`.
![image](https://github.com/user-attachments/assets/1d68f7ab-6fae-40c3-a7a8-731f7cc5dff9)

