### PR TITLE
Definerer ytelseType som enum med kodeverdi.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgavetypeDataDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgavetypeDataDAO.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.ArbeidOgFrilansRegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.RegisterinntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.YtelseRegisterInntektDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.YtelseType
 import java.time.LocalDate
 
 @JsonTypeInfo(
@@ -76,6 +77,6 @@ data class ArbeidOgFrilansRegisterInntektDAO(
 
 data class YtelseRegisterInntektDAO(
     @JsonProperty("inntekt") val inntekt: Int,
-    @JsonProperty("ytelsetype") val ytelsetype: String,
+    @JsonProperty("ytelsetype") val ytelsetype: YtelseType,
 )
 

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
@@ -35,6 +35,7 @@ import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterIn
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektOppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektYtelseDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.YtelseType
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -268,8 +269,8 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
                         RegisterInntektArbeidOgFrilansDTO(2000, "321"),
                     ),
                     registerinntekterForYtelse = listOf(
-                        RegisterInntektYtelseDTO(1000, "Sykepenger"),
-                        RegisterInntektYtelseDTO(2000, "Pleiepenger"),
+                        RegisterInntektYtelseDTO(1000, YtelseType.SYKEPENGER),
+                        RegisterInntektYtelseDTO(2000, YtelseType.PLEIEPENGER_SYKT_BARN),
                     )
                 )
             )

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
@@ -2,6 +2,7 @@ package no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.ProgramperiodeDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.YtelseType
 
 import java.time.LocalDate
 
@@ -36,5 +37,5 @@ data class ArbeidOgFrilansRegisterInntektDTO(
 
 data class YtelseRegisterInntektDTO(
     @JsonProperty("inntekt") val inntekt: Int,
-    @JsonProperty("ytelsetype") val ytelsetype: String,
+    @JsonProperty("ytelsetype") val ytelsetype: YtelseType,
 )

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTO.kt
@@ -30,11 +30,11 @@ data class RegisterInntektArbeidOgFrilansDTO (
     @JsonProperty("arbeidsgiverIdent") val arbeidsgiverIdent: String,
 )
 
-enum class YtelseType(@JsonValue val kode: String) {
-    SYKEPENGER("SP"),
-    OMSORGSPENGER("OP"),
-    PLEIEPENGER_SYKT_BARN("PSB"),
-    PLEIEPENGER_LIVETS_SLUTTFASE("PLS"),
-    OPPLAERINGSPENGER("OLP")
+enum class YtelseType {
+    SYKEPENGER,
+    OMSORGSPENGER,
+    PLEIEPENGER_SYKT_BARN,
+    PLEIEPENGER_LIVETS_SLUTTFASE,
+    OPPLAERINGSPENGER
 }
 

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTO.kt
@@ -1,6 +1,7 @@
 package no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonValue
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -21,11 +22,19 @@ data class RegisterInntektDTO(
 
 data class RegisterInntektYtelseDTO (
     @JsonProperty("beløp") val beløp: Int,
-    @JsonProperty("ytelseType") val ytelseType: String,
+    @JsonProperty("ytelseType") val ytelseType: YtelseType,
 )
 
 data class RegisterInntektArbeidOgFrilansDTO (
     @JsonProperty("beløp") val beløp: Int,
     @JsonProperty("arbeidsgiverIdent") val arbeidsgiverIdent: String,
 )
+
+enum class YtelseType(@JsonValue val kode: String) {
+    SYKEPENGER("SP"),
+    OMSORGSPENGER("OP"),
+    PLEIEPENGER_SYKT_BARN("PSB"),
+    PLEIEPENGER_LIVETS_SLUTTFASE("PLS"),
+    OPPLAERINGSPENGER("OLP")
+}
 

--- a/kontrakt/src/test/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTOTest.kt
+++ b/kontrakt/src/test/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTOTest.kt
@@ -46,6 +46,58 @@ class RegisterInntektOppgaveDTOTest {
         assertEquals("910909088", dto.registerInntekter.registerinntekterForArbeidOgFrilans?.get(0)?.arbeidsgiverIdent)
     }
 
+    @Test
+    fun `skal serialisere input`() {
+        //language=JSON
+        val utenYtelse = """
+            {
+              "deltakerIdent": "99154987302",
+              "referanse": "0fc3f6fc-0eb1-4c51-9822-61ab3e71090b",
+              "frist": "2025-04-04T07:37:20.251902",
+              "fomDato": "2025-01-01",
+              "tomDato": "2025-02-01",
+              "registerInntekter": {
+                "registerinntekterForArbeidOgFrilans": [
+                  {
+                    "beløp": 10000,
+                    "arbeidsgiverIdent": "910909088"
+                  }
+                ],
+                "registerinntekterForYtelse": [
+                  {
+                    "beløp": 1,
+                    "ytelseType": "SP"
+                  },
+                  {
+                    "beløp": 2,
+                    "ytelseType": "PSB"
+                  },
+                  {
+                    "beløp": 3,
+                    "ytelseType": "PLS"
+                  },
+                {
+                    "beløp": 4,
+                    "ytelseType": "OP"
+                },
+                {
+                    "beløp": 5,
+                    "ytelseType": "OLP"
+                }
+              ]
+            }
+            }"""
+        val dto: RegisterInntektOppgaveDTO = mapper.readValue(utenYtelse, RegisterInntektOppgaveDTO::class.java)
+
+        assertEquals("99154987302", dto.deltakerIdent)
+        assertEquals(5, dto.registerInntekter.registerinntekterForYtelse?.size)
+        assertEquals(1, dto.registerInntekter.registerinntekterForYtelse?.first()?.beløp)
+
+        assertEquals(1, dto.registerInntekter.registerinntekterForArbeidOgFrilans?.size)
+        assertEquals(10000, dto.registerInntekter.registerinntekterForArbeidOgFrilans?.get(0)?.beløp)
+        assertEquals("910909088", dto.registerInntekter.registerinntekterForArbeidOgFrilans?.get(0)?.arbeidsgiverIdent)
+    }
+
 
     @Test
     fun `skal serialisere input uten arbeidsinntekt`() {

--- a/kontrakt/src/test/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTOTest.kt
+++ b/kontrakt/src/test/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTOTest.kt
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 
 class RegisterInntektOppgaveDTOTest {
 
@@ -46,8 +48,9 @@ class RegisterInntektOppgaveDTOTest {
         assertEquals("910909088", dto.registerInntekter.registerinntekterForArbeidOgFrilans?.get(0)?.arbeidsgiverIdent)
     }
 
-    @Test
-    fun `skal serialisere input`() {
+    @ParameterizedTest
+    @EnumSource(YtelseType::class)
+    fun `skal serialisere input med ytelse`(ytelseType: YtelseType) {
         //language=JSON
         val utenYtelse = """
             {
@@ -57,45 +60,22 @@ class RegisterInntektOppgaveDTOTest {
               "fomDato": "2025-01-01",
               "tomDato": "2025-02-01",
               "registerInntekter": {
-                "registerinntekterForArbeidOgFrilans": [
-                  {
-                    "beløp": 10000,
-                    "arbeidsgiverIdent": "910909088"
-                  }
-                ],
                 "registerinntekterForYtelse": [
                   {
-                    "beløp": 1,
-                    "ytelseType": "SP"
-                  },
-                  {
-                    "beløp": 2,
-                    "ytelseType": "PSB"
-                  },
-                  {
-                    "beløp": 3,
-                    "ytelseType": "PLS"
-                  },
-                {
-                    "beløp": 4,
-                    "ytelseType": "OP"
-                },
-                {
-                    "beløp": 5,
-                    "ytelseType": "OLP"
-                }
+                    "beløp": 10000,
+                    "ytelseType": "${ytelseType.kode}"
+                  }
               ]
             }
             }"""
         val dto: RegisterInntektOppgaveDTO = mapper.readValue(utenYtelse, RegisterInntektOppgaveDTO::class.java)
 
         assertEquals("99154987302", dto.deltakerIdent)
-        assertEquals(5, dto.registerInntekter.registerinntekterForYtelse?.size)
-        assertEquals(1, dto.registerInntekter.registerinntekterForYtelse?.first()?.beløp)
+        assertEquals(1, dto.registerInntekter.registerinntekterForYtelse?.size)
 
-        assertEquals(1, dto.registerInntekter.registerinntekterForArbeidOgFrilans?.size)
-        assertEquals(10000, dto.registerInntekter.registerinntekterForArbeidOgFrilans?.get(0)?.beløp)
-        assertEquals("910909088", dto.registerInntekter.registerinntekterForArbeidOgFrilans?.get(0)?.arbeidsgiverIdent)
+        val inntektYtelseDTO = dto.registerInntekter.registerinntekterForYtelse?.first()
+        assertEquals(10000, inntektYtelseDTO?.beløp)
+        assertEquals(ytelseType, inntektYtelseDTO?.ytelseType)
     }
 
 

--- a/kontrakt/src/test/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTOTest.kt
+++ b/kontrakt/src/test/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/registerinntekt/RegisterInntektOppgaveDTOTest.kt
@@ -63,7 +63,7 @@ class RegisterInntektOppgaveDTOTest {
                 "registerinntekterForYtelse": [
                   {
                     "beløp": 10000,
-                    "ytelseType": "${ytelseType.kode}"
+                    "ytelseType": "${ytelseType.name}"
                   }
               ]
             }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Idag sendes og presenteres det kodeverdi for ytelsetype, noe som ikke er veldig forståelig for deltaker.
Bakgrunn: https://jira.adeo.no/browse/TSFF-1481 

### **Løsning**
Definerer ytelsetype som enum med kodeverdi som gjør det lettere å mappe enum til foretrukket tekst ved presentasjon.