### PR TITLE
Varsler deltaker om innmelding på mine-sider.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/config/DeltakerappConfig.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/config/DeltakerappConfig.kt
@@ -1,0 +1,18 @@
+package no.nav.ung.deltakelseopplyser.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class DeltakerappConfig(
+    @Value("\${UNGDOMSYTELSE_DELTAKER_BASE_URL}") private val deltakerAppBaseUrl: String
+) {
+
+    fun getOppgaveUrl(oppgaveId: String): String {
+        return "$deltakerAppBaseUrl/oppgave/$oppgaveId"
+    }
+
+    fun getSøknadUrl(): String {
+        return "$deltakerAppBaseUrl/ungdomsytelse-deltaker"
+    }
+}

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -3,13 +3,16 @@ package no.nav.ung.deltakelseopplyser.domene.register
 import com.ninjasquad.springmockk.MockkBean
 import io.hypersistence.utils.hibernate.type.range.Range
 import io.mockk.every
+import io.mockk.justRun
 import jakarta.persistence.EntityManager
 import no.nav.pdl.generated.enums.IdentGruppe
 import no.nav.pdl.generated.hentident.IdentInformasjon
+import no.nav.ung.deltakelseopplyser.config.DeltakerappConfig
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService.Companion.rapporteringsPerioder
+import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngSakService
@@ -48,6 +51,7 @@ import java.util.*
 @Import(
     UngdomsprogramregisterService::class,
     DeltakerService::class,
+    DeltakerappConfig::class
 )
 class UngdomsprogramregisterServiceTest {
 
@@ -59,6 +63,9 @@ class UngdomsprogramregisterServiceTest {
 
     @Autowired
     lateinit var entityManager: EntityManager
+
+    @MockkBean
+    lateinit var mineSiderVarselService: MineSiderVarselService
 
     @MockkBean(relaxed = true)
     lateinit var ungSakService: UngSakService
@@ -75,6 +82,7 @@ class UngdomsprogramregisterServiceTest {
     @BeforeEach
     fun setUp() {
         repository.deleteAll()
+        justRun { mineSiderVarselService.opprettVarsel(any(), any(), any(), any(), any(), any()) }
     }
 
     @AfterAll

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
@@ -2,6 +2,9 @@ package no.nav.ung.deltakelseopplyser.domene.soknad
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import io.mockk.just
+import io.mockk.justRun
+import io.mockk.runs
 import no.nav.k9.søknad.Søknad
 import no.nav.k9.søknad.felles.Kildesystem
 import no.nav.k9.søknad.felles.personopplysninger.Søker
@@ -11,6 +14,7 @@ import no.nav.k9.søknad.ytelse.ung.v1.UngSøknadstype
 import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
 import no.nav.pdl.generated.enums.IdentGruppe
 import no.nav.pdl.generated.hentident.IdentInformasjon
+import no.nav.ung.deltakelseopplyser.config.DeltakerappConfig
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService
@@ -20,6 +24,7 @@ import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.soknad.kafka.Ungdomsytelsesøknad
+import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
@@ -46,7 +51,8 @@ import java.time.ZonedDateTime
     DeltakerService::class,
     UngdomsytelsesøknadService::class,
     UngdomsprogramregisterService::class,
-    RapportertInntektService::class
+    RapportertInntektService::class,
+    DeltakerappConfig::class
 )
 class UngdomsytelsesøknadServiceTest {
 
@@ -58,6 +64,9 @@ class UngdomsytelsesøknadServiceTest {
 
     @MockkBean
     lateinit var kontoregisterService: KontoregisterService
+
+    @MockkBean
+    lateinit var mineSiderVarselService: MineSiderVarselService
 
     @Autowired
     lateinit var ungdomsprogramDeltakelseRepository: UngdomsprogramDeltakelseRepository
@@ -71,6 +80,7 @@ class UngdomsytelsesøknadServiceTest {
     @BeforeAll
     fun setUp() {
         ungdomsprogramDeltakelseRepository.deleteAll()
+        justRun { mineSiderVarselService.opprettVarsel(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
### **Behov / Bakgrunn**
Deltaker skal varsles om at hen er meldt inn i ungdomsprogrammet og kunne navigere seg til søknaden.

### **Løsning**
Bruker min-side varsling med typen `Beskjed` til å varsle deltaker når de er meldt inn i programmet.
Varslen er aktiv i 3 måneder fra innmeldingen.

### **Andre endringer**
- Refaktorerer MineSiderVarselService til å støtte både Beskjed og Oppgave.
- Trekker ut `deltakerAppBaseUrl` til egen config `DeltakerappConfig`.
- Oppretter url for oppgave og beskjed i `DeltakerappConfig`.
