### PR TITLE
Legger til støtte for å åpne/lukke oppgaver.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -154,6 +154,7 @@ class OppgaveDAO(
     }
 
     fun markerSomLukket(): OppgaveDAO {
+        settStatus(OppgaveStatus.LUKKET)
         this.lukketDato = ZonedDateTime.now(ZoneOffset.UTC)
         return this
     }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -69,6 +69,12 @@ class OppgaveDAO(
 
     @Column(name = "løst_dato")
     var løstDato: ZonedDateTime? = null,
+
+    @Column(name = "åpnet_dato")
+    var åpnetDato: ZonedDateTime? = null,
+
+    @Column(name = "lukket_dato")
+    var lukketDato: ZonedDateTime? = null,
 ) {
 
     companion object {
@@ -79,7 +85,9 @@ class OppgaveDAO(
             bekreftelse = oppgaveBekreftelse?.tilDTO(),
             status = status,
             opprettetDato = opprettetDato,
-            løstDato = løstDato
+            løstDato = løstDato,
+            åpnetDato = åpnetDato,
+            lukketDato = lukketDato,
         )
 
         fun OppgaveBekreftelse.tilDTO(): BekreftelseDTO = BekreftelseDTO(
@@ -138,6 +146,16 @@ class OppgaveDAO(
 
     fun markerSomUtløpt(): OppgaveDAO {
         return settStatus(OppgaveStatus.UTLØPT)
+    }
+
+    fun markerSomÅpnet(): OppgaveDAO {
+        this.åpnetDato = ZonedDateTime.now(ZoneOffset.UTC)
+        return this
+    }
+
+    fun markerSomLukket(): OppgaveDAO {
+        this.lukketDato = ZonedDateTime.now(ZoneOffset.UTC)
+        return this
     }
 
     fun settStatus(oppgaveStatus: OppgaveStatus): OppgaveDAO {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
@@ -101,13 +101,13 @@ class UngdomsprogramRegisterDeltakerController(
     }
 
     @GetMapping("/oppgave/åpnet/{oppgaveReferanse}", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Operation(summary = "Markerer en oppgave som lest")
+    @Operation(summary = "Markerer en oppgave som åpnet")
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     fun markerOppgaveSomÅpnet(@PathVariable oppgaveReferanse: UUID): OppgaveDTO {
         val (deltaker, oppgave) = hentDeltakerOppgave(oppgaveReferanse)
 
-        val oppdatertOppgave = oppgave.markerSomLukket()
+        val oppdatertOppgave = oppgave.markerSomÅpnet()
         deltakerService.oppdaterDeltaker(deltaker)
 
         mineSiderVarselService.deaktiverOppgave(oppgaveReferanse.toString())

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
@@ -88,7 +88,7 @@ class UngdomsprogramRegisterDeltakerController(
             )
     }
 
-    @GetMapping("/oppgave/lukk/{oppgaveReferanse}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping("/oppgave/{oppgaveReferanse}/lukk", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Markerer en oppgave som lukket")
     @ResponseStatus(HttpStatus.OK)
     fun markerOppgaveSomLukket(@PathVariable oppgaveReferanse: UUID): OppgaveDTO {
@@ -100,7 +100,7 @@ class UngdomsprogramRegisterDeltakerController(
         return oppdatertOppgave.tilDTO()
     }
 
-    @GetMapping("/oppgave/åpnet/{oppgaveReferanse}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping("/oppgave/{oppgaveReferanse}/åpnet", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Markerer en oppgave som åpnet")
     @ResponseStatus(HttpStatus.OK)
     @Transactional

--- a/app/src/main/resources/db/migration/V10__oppgave_åpnet_lest_kolonner.sql
+++ b/app/src/main/resources/db/migration/V10__oppgave_åpnet_lest_kolonner.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oppgave
+    ADD COLUMN åpnet_dato TIMESTAMP NULL,
+    ADD COLUMN lukket_dato TIMESTAMP NULL;

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
@@ -12,4 +12,6 @@ data class OppgaveDTO(
     @JsonProperty("status") val status: OppgaveStatus,
     @JsonProperty("opprettetDato") val opprettetDato: ZonedDateTime,
     @JsonProperty("løstDato") val løstDato: ZonedDateTime?,
+    @JsonProperty("åpnetDato") val åpnetDato: ZonedDateTime?,
+    @JsonProperty("lukketDato") val lukketDato: ZonedDateTime?,
 )

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveStatus.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveStatus.kt
@@ -4,5 +4,6 @@ enum class OppgaveStatus {
     LØST,
     ULØST,
     AVBRUTT,
-    UTLØPT
+    UTLØPT,
+    LUKKET
 }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det skal være mulig å vite når en oppgave blir åpnet og/eller lukket.

### **Løsning**
- Utvider `OppgaveDAO` med `åpnetDato` og `lukketDato` felter.
- Migrere `oppgave` tabellen med de nye kolonnene.
- Legger til endepunkter for å kunne markere oppgaven som åpnet og/eller lukket.