### PR TITLE
Henter rapportert inntekt for løst oppgave om inntektsrapportering.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/audit/SporingsloggService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/audit/SporingsloggService.kt
@@ -1,21 +1,24 @@
 package no.nav.ung.deltakelseopplyser.audit
 
-import no.nav.k9.felles.log.audit.*
+import no.nav.k9.felles.log.audit.Auditdata
+import no.nav.k9.felles.log.audit.AuditdataHeader
+import no.nav.k9.felles.log.audit.CefField
+import no.nav.k9.felles.log.audit.CefFieldName
+import no.nav.k9.felles.log.audit.EventClassId
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.sif.abac.kontrakt.person.PersonIdent
-import no.nav.ung.deltakelseopplyser.utils.personIdent
-import no.nav.ung.deltakelseopplyser.utils.subject
+import no.nav.ung.deltakelseopplyser.utils.navIdent
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
 @Service
-class SporingsloggService (
+class SporingsloggService(
     private val auditlogger: Auditlogger,
-    private val tokenValidationContextHolder: SpringTokenValidationContextHolder
-){
+    private val tokenValidationContextHolder: SpringTokenValidationContextHolder,
+) {
 
-    fun loggLesetilgang(url: String, beskrivelse: String, bruker : PersonIdent) {
+    fun loggLesetilgang(url: String, beskrivelse: String, bruker: PersonIdent) {
         auditlogger.logg(
             Auditdata(
                 AuditdataHeader.Builder()
@@ -28,7 +31,7 @@ class SporingsloggService (
                 setOf(
                     CefField(CefFieldName.EVENT_TIME, LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) * 1000L),
                     CefField(CefFieldName.REQUEST, url),
-                    CefField(CefFieldName.USER_ID, tokenValidationContextHolder.subject()),
+                    CefField(CefFieldName.USER_ID, tokenValidationContextHolder.navIdent()),
                     CefField(CefFieldName.BERORT_BRUKER_ID, bruker.ident)
                 )
             )

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/audit/SporingsloggService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/audit/SporingsloggService.kt
@@ -28,7 +28,7 @@ class SporingsloggService (
                 setOf(
                     CefField(CefFieldName.EVENT_TIME, LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) * 1000L),
                     CefField(CefFieldName.REQUEST, url),
-                    CefField(CefFieldName.USER_ID, tokenValidationContextHolder.personIdent()),
+                    CefField(CefFieldName.USER_ID, tokenValidationContextHolder.subject()),
                     CefField(CefFieldName.BERORT_BRUKER_ID, bruker.ident)
                 )
             )

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/RapportertInntektService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/RapportertInntektService.kt
@@ -36,7 +36,6 @@ class RapportertInntektService(
             .first
 
         return RapportertInntektPeriodeinfoDTO(
-            oppgaveReferanse = UUID.fromString(søknadId.id),
             fraOgMed = oppgittInntektForPeriode.periode.fraOgMed,
             tilOgMed = oppgittInntektForPeriode.periode.tilOgMed,
             arbeidstakerOgFrilansInntekt = oppgittInntektForPeriode.arbeidstakerOgFrilansInntekt,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/RapportertInntektService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/RapportertInntektService.kt
@@ -1,69 +1,46 @@
 package no.nav.ung.deltakelseopplyser.domene.inntekt
 
-import no.nav.fpsak.tidsserie.LocalDateTimeline
 import no.nav.k9.søknad.JsonUtils
 import no.nav.k9.søknad.Søknad
 import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
-import no.nav.k9.søknad.ytelse.ung.v1.inntekt.OppgittInntektForPeriode
-import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.repository.RapportertInntektRepository
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseDAO
-import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.RapportPeriodeinfoDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.RapportertInntektPeriodeinfoDTO
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 import org.springframework.stereotype.Service
-import java.time.LocalDate
-import java.time.Period
+import org.springframework.web.ErrorResponseException
+import java.util.*
 
 @Service
 class RapportertInntektService(
     private val rapportertInntektRepository: RapportertInntektRepository,
-    private val deltakerService: DeltakerService,
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(RapportertInntektService::class.java)
-
-        fun UngdomsprogramDeltakelseDAO.rapporteringsPerioder(): List<RapportPeriodeinfoDTO> {
-            val startDato = getFom().withDayOfMonth(1)
-            val sluttDato = getTom() ?: startDato.withDayOfMonth(startDato.lengthOfMonth())
-            val tidslinje = LocalDateTimeline(getFom(), sluttDato, this)
-            val månedTidslinje = tidslinje.splitAtRegular(startDato, tidslinje.maxLocalDate, Period.ofMonths(1))
-            return månedTidslinje.toSegments().map { segment ->
-                RapportPeriodeinfoDTO(
-                    fraOgMed = segment.fom,
-                    tilOgMed = segment.tom,
-                    harRapportert = false
-                )
-            }
-        }
     }
 
-    fun hentRapporteringsperioder(deltakelse: UngdomsprogramDeltakelseDAO): List<RapportPeriodeinfoDTO> {
-        val deltakerIdenter = deltakerService.hentDeltakterIdenter(deltakelse.deltaker.deltakerIdent)
-        val rapporterteInntekter = rapportertInntektRepository
-            .findBySøkerIdentIn(deltakerIdenter)
-            .flatMap { oppgittInntekt ->
-                JsonUtils.fromString(oppgittInntekt.inntekt, Søknad::class.java)
-                    .getYtelse<Ungdomsytelse>()
-                    .inntekter.oppgittePeriodeinntekter
-            }
+    fun finnRapportertInntektGittOppgaveReferanse(oppgaveReferanse: UUID): RapportertInntektPeriodeinfoDTO? {
+        return rapportertInntektRepository
+            .finnRapportertInntektGittOppgaveReferanse(oppgaveReferanse.toString())
+            ?.let { ungRapportertInntektDAO ->
+                JsonUtils.fromString(ungRapportertInntektDAO.inntekt, Søknad::class.java)
+            }?.rapportertInntektPeriodeInfo()
+            ?.also { logger.info("Fant rapportert inntekt i perioden [${it.fraOgMed} - ${it.tilOgMed}] for oppgave med referanse $oppgaveReferanse: $it") }
+    }
 
-        logger.info(
-            "Fant ${rapporterteInntekter.size} rapporterte inntekter for deltakelse ${deltakelse.id}. Perioder: {}",
-            rapporterteInntekter.map { it.periode })
+    private fun Søknad.rapportertInntektPeriodeInfo(): RapportertInntektPeriodeinfoDTO {
+        val oppgittInntektForPeriode = getYtelse<Ungdomsytelse>()
+            .inntekter
+            .oppgittePeriodeinntekter
+            .first
 
-        return deltakelse.rapporteringsPerioder()
-            .map { rapporteringsPeriode ->
-                rapporterteInntekter
-                    .find { it.periode.fraOgMed <= rapporteringsPeriode.fraOgMed && it.periode.tilOgMed >= rapporteringsPeriode.tilOgMed }
-                    ?.let { inntekt: OppgittInntektForPeriode ->
-                        RapportPeriodeinfoDTO(
-                            fraOgMed = rapporteringsPeriode.fraOgMed,
-                            tilOgMed = rapporteringsPeriode.tilOgMed,
-                            harRapportert = true,
-                            arbeidstakerOgFrilansInntekt = inntekt.arbeidstakerOgFrilansInntekt,
-                            inntektFraYtelse = inntekt.ytelse
-                        )
-                    } ?: rapporteringsPeriode
-            }
+        return RapportertInntektPeriodeinfoDTO(
+            oppgaveReferanse = UUID.fromString(søknadId.id),
+            fraOgMed = oppgittInntektForPeriode.periode.fraOgMed,
+            tilOgMed = oppgittInntektForPeriode.periode.tilOgMed,
+            arbeidstakerOgFrilansInntekt = oppgittInntektForPeriode.arbeidstakerOgFrilansInntekt,
+            inntektFraYtelse = oppgittInntektForPeriode.ytelse
+        )
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/repository/RapportertInntektRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/repository/RapportertInntektRepository.kt
@@ -2,10 +2,21 @@ package no.nav.ung.deltakelseopplyser.domene.inntekt.repository
 
 import no.nav.ung.deltakelseopplyser.config.TxConfiguration.Companion.TRANSACTION_MANAGER
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional(TRANSACTION_MANAGER)
 interface RapportertInntektRepository : JpaRepository<UngRapportertInntektDAO, String> {
 
-    fun findBySøkerIdentIn(søkerIdents: List<String>): List<UngRapportertInntektDAO>
+    @Query(
+        value = """
+            SELECT u.*
+            FROM ung_rapportert_inntekt u
+            WHERE u.inntekt->'søknad'->>'søknadId' = :oppgaveReferanse
+            LIMIT 1
+        """,
+        nativeQuery = true
+    )
+    fun finnRapportertInntektGittOppgaveReferanse(@Param("oppgaveReferanse") oppgaveReferanse: String): UngRapportertInntektDAO?
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -13,6 +13,7 @@ import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.ArbeidOgFrilansRegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.BekreftelseDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeData
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
@@ -115,10 +116,16 @@ class OppgaveDAO(
                 registerinntekt.tilDTO()
             )
 
-            is InntektsrapporteringOppgavetypeDataDAO -> InntektsrapporteringOppgavetypeDataDTO(
-                fraOgMed = fomDato,
-                tilOgMed = tomDato
-            )
+            is InntektsrapporteringOppgavetypeDataDAO -> {
+                val base = InntektsrapporteringOppgavetypeData(
+                    fraOgMed = this.fomDato,
+                    tilOgMed = this.tomDato
+                )
+                InntektsrapporteringOppgavetypeDataDTO(
+                    base = base,
+                    rapportertInntekt = null
+                )
+            }
         }
 
         fun RegisterinntektDAO.tilDTO() = RegisterinntektDTO(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
-import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.RapportertInntektPeriodeinfoDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.ArbeidOgFrilansRegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.BekreftelseDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
+import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.RapportertInntektPeriodeinfoDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.ArbeidOgFrilansRegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.BekreftelseDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
@@ -78,11 +79,12 @@ class OppgaveDAO(
 ) {
 
     companion object {
-        fun OppgaveDAO.tilDTO() = OppgaveDTO(
+        fun OppgaveDAO.tilDTO(rapporterteInntektPerioder: RapportertInntektPeriodeinfoDTO? = null) = OppgaveDTO(
             oppgaveReferanse = oppgaveReferanse,
             oppgavetype = oppgavetype,
             oppgavetypeData = oppgavetypeDataDAO.tilDTO(),
             bekreftelse = oppgaveBekreftelse?.tilDTO(),
+            rapportertInntekt = rapporterteInntektPerioder,
             status = status,
             opprettetDato = opprettetDato,
             løstDato = løstDato,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -79,12 +79,11 @@ class OppgaveDAO(
 ) {
 
     companion object {
-        fun OppgaveDAO.tilDTO(rapporterteInntektPerioder: RapportertInntektPeriodeinfoDTO? = null) = OppgaveDTO(
+        fun OppgaveDAO.tilDTO() = OppgaveDTO(
             oppgaveReferanse = oppgaveReferanse,
             oppgavetype = oppgavetype,
             oppgavetypeData = oppgavetypeDataDAO.tilDTO(),
             bekreftelse = oppgaveBekreftelse?.tilDTO(),
-            rapportertInntekt = rapporterteInntektPerioder,
             status = status,
             opprettetDato = opprettetDato,
             løstDato = løstDato,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgavetypeDataDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgavetypeDataDAO.kt
@@ -89,7 +89,6 @@ data class ArbeidOgFrilansRegisterInntektDAO(
     @JsonProperty("arbeidsgiver") val arbeidsgiver: String,
 )
 
-
 data class YtelseRegisterInntektDAO(
     @JsonProperty("inntekt") val inntekt: Int,
     @JsonProperty("ytelsetype") val ytelsetype: YtelseType,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -24,7 +24,12 @@ import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.YtelseRegisterInn
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.*
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.SettTilUtløptDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.inntektsrapportering.InntektsrapporteringOppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.EndretProgamperiodeOppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektOppgaveDTO
@@ -132,7 +137,11 @@ class OppgaveUngSakController(
         val uløstOppgaveISammePeriode = deltaker.oppgaver
             .filter { it.oppgavetype == settTilUtløptDTO.oppgavetype }
             .find {
-                it.oppgavetype == settTilUtløptDTO.oppgavetype && gjelderSammePeriodeForInntektsrapportering(it, settTilUtløptDTO.fomDato, settTilUtløptDTO.tomDato) && it.status == OppgaveStatus.ULØST
+                it.oppgavetype == settTilUtløptDTO.oppgavetype && gjelderSammePeriodeForInntektsrapportering(
+                    it,
+                    settTilUtløptDTO.fomDato,
+                    settTilUtløptDTO.tomDato
+                ) && it.status == OppgaveStatus.ULØST
             }
 
         if (uløstOppgaveISammePeriode != null) {
@@ -365,10 +374,12 @@ class OppgaveUngSakController(
         fom: LocalDate,
         tom: LocalDate,
     ): Boolean {
-        val eksisterende: InntektsrapporteringOppgavetypeDataDTO =
-            oppgaveDAO.oppgavetypeDataDAO.tilDTO() as InntektsrapporteringOppgavetypeDataDTO
-        logger.info("Sjekker om oppgave med oppgaveReferanse ${oppgaveDAO.oppgaveReferanse} gjelder samme periode som ny oppgave. Eksisterende: [${eksisterende.fraOgMed}/${eksisterende.tilOgMed}], Ny: [$fom/$tom]")
-        return !eksisterende.fraOgMed.isAfter(tom) && !eksisterende.tilOgMed.isBefore(fom)
+        val eksisterende = oppgaveDAO.oppgavetypeDataDAO.tilDTO() as InntektsrapporteringOppgavetypeDataDTO
+        val eksisterendeFraOgMed = eksisterende.base.fraOgMed
+        val eksisterendeTilOgMed = eksisterende.base.tilOgMed
+
+        logger.info("Sjekker om oppgave med oppgaveReferanse ${oppgaveDAO.oppgaveReferanse} gjelder samme periode som ny oppgave. Eksisterende: [$eksisterendeFraOgMed/$eksisterendeTilOgMed], Ny: [$fom/$tom]")
+        return !eksisterendeFraOgMed.isAfter(tom) && !eksisterendeTilOgMed.isBefore(fom)
     }
 
     private fun forsikreOppgaveIkkeErLøst(oppgave: OppgaveDAO) {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -24,7 +24,6 @@ import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.YtelseRegisterInn
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
@@ -374,9 +373,9 @@ class OppgaveUngSakController(
         fom: LocalDate,
         tom: LocalDate,
     ): Boolean {
-        val eksisterende = oppgaveDAO.oppgavetypeDataDAO.tilDTO() as InntektsrapporteringOppgavetypeDataDTO
-        val eksisterendeFraOgMed = eksisterende.base.fraOgMed
-        val eksisterendeTilOgMed = eksisterende.base.tilOgMed
+        val eksisterende = oppgaveDAO.oppgavetypeDataDAO as InntektsrapporteringOppgavetypeDataDAO
+        val eksisterendeFraOgMed = eksisterende.fomDato
+        val eksisterendeTilOgMed = eksisterende.tomDato
 
         logger.info("Sjekker om oppgave med oppgaveReferanse ${oppgaveDAO.oppgaveReferanse} gjelder samme periode som ny oppgave. Eksisterende: [$eksisterendeFraOgMed/$eksisterendeTilOgMed], Ny: [$fom/$tom]")
         return !eksisterendeFraOgMed.isAfter(tom) && !eksisterendeTilOgMed.isBefore(fom)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenUtils.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenUtils.kt
@@ -8,6 +8,9 @@ object TokenClaims {
 
     // Brukerident ligger i sub claim på tokenet for flyten NAV loginservice -> tokenx
     const val CLAIM_SUB = "sub"
+
+    // NAV ident ligger i navident claim på tokenet flyten azure.
+    const val NAV_IDENT = "NAVident"
 }
 
 fun SpringTokenValidationContextHolder.personIdent(): String {
@@ -29,6 +32,17 @@ fun SpringTokenValidationContextHolder.subject(): String {
         ?: throw IllegalStateException("Ingen gyldige tokens i Authorization headeren")
 
     val sub = jwtToken.jwtTokenClaims.getStringClaim(TokenClaims.CLAIM_SUB)
+    return when {
+        !sub.isNullOrBlank() -> sub
+        else -> throw IllegalStateException("Ugyldig token. Token inneholdt verken sub eller pid claim")
+    }
+}
+
+fun SpringTokenValidationContextHolder.navIdent(): String {
+    val jwtToken = getTokenValidationContext().firstValidToken
+        ?: throw IllegalStateException("Ingen gyldige tokens i Authorization headeren")
+
+    val sub = jwtToken.jwtTokenClaims.getStringClaim(TokenClaims.NAV_IDENT)
     return when {
         !sub.isNullOrBlank() -> sub
         else -> throw IllegalStateException("Ugyldig token. Token inneholdt verken sub eller pid claim")

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenUtils.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenUtils.kt
@@ -42,9 +42,9 @@ fun SpringTokenValidationContextHolder.navIdent(): String {
     val jwtToken = getTokenValidationContext().firstValidToken
         ?: throw IllegalStateException("Ingen gyldige tokens i Authorization headeren")
 
-    val sub = jwtToken.jwtTokenClaims.getStringClaim(TokenClaims.NAV_IDENT)
+    val navIdent = jwtToken.jwtTokenClaims.getStringClaim(TokenClaims.NAV_IDENT)
     return when {
-        !sub.isNullOrBlank() -> sub
+        !navIdent.isNullOrBlank() -> navIdent
         else -> throw IllegalStateException("Ugyldig token. Token inneholdt verken sub eller pid claim")
     }
 }

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/repository/RapportertInntektRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/repository/RapportertInntektRepositoryTest.kt
@@ -1,0 +1,90 @@
+package no.nav.ung.deltakelseopplyser.domene.inntekt.repository
+
+import jakarta.persistence.EntityManager
+import no.nav.k9.søknad.JsonUtils
+import no.nav.k9.søknad.Søknad
+import no.nav.k9.søknad.felles.Kildesystem
+import no.nav.k9.søknad.felles.personopplysninger.Søker
+import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer
+import no.nav.k9.søknad.felles.type.Språk
+import no.nav.k9.søknad.ytelse.ung.v1.UngSøknadstype
+import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
+import no.nav.k9.søknad.ytelse.ung.v1.inntekt.OppgittInntekt
+import no.nav.ung.deltakelseopplyser.domene.soknad.kafka.Ungdomsytelsesøknad
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.ZonedDateTime
+import java.util.*
+
+@DataJpaTest
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(SpringExtension::class)
+@AutoConfigureTestDatabase(
+    replace = AutoConfigureTestDatabase.Replace.NONE
+)
+class RapportertInntektRepositoryTest {
+
+    @Autowired
+    lateinit var rapportertInntektRepository: RapportertInntektRepository
+
+    @Autowired
+    lateinit var entityManager: EntityManager
+
+    @BeforeEach
+    fun setUp() {
+        rapportertInntektRepository.deleteAll()
+    }
+
+    @Test
+    fun `Forventer å kunne hente opp rapportert inntekt gitt oppgavereferanse`() {
+        val oppgaveReferanse = UUID.randomUUID()
+
+        val rapportertInntektDAO = UngRapportertInntektDAO(
+            journalpostId = "123",
+            søkerIdent = "12345678901",
+            opprettetDato = ZonedDateTime.now(),
+            oppdatertDato = ZonedDateTime.now(),
+            inntekt = JsonUtils.toString(
+                lagInntektsrapporteringsSøknad(
+                    søknadId = oppgaveReferanse,
+                    søkerIdent = "12345678901"
+                )
+            ).also { println(it) },
+        )
+
+        rapportertInntektRepository.save(rapportertInntektDAO)
+        entityManager.flush()
+
+        val rapportertInntekt =
+            rapportertInntektRepository.finnRapportertInntektGittOppgaveReferanse(oppgaveReferanse = oppgaveReferanse.toString())
+
+        assertThat(rapportertInntekt).isNotNull
+    }
+
+    private fun lagInntektsrapporteringsSøknad(
+        søknadId: UUID,
+        søkerIdent: String,
+    ) = Ungdomsytelsesøknad(
+        journalpostId = "671161658",
+        søknad = Søknad()
+            .medSøknadId(søknadId.toString())
+            .medMottattDato(ZonedDateTime.now())
+            .medSpråk(Språk.NORSK_BOKMÅL)
+            .medKildesystem(Kildesystem.SØKNADSDIALOG)
+            .medSøker(Søker(NorskIdentitetsnummer.of(søkerIdent)))
+            .medYtelse(
+                Ungdomsytelse()
+                    .medSøknadType(UngSøknadstype.RAPPORTERING_SØKNAD)
+                    .medInntekter(OppgittInntekt(setOf()))
+            )
+    )
+}

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -1,17 +1,14 @@
 package no.nav.ung.deltakelseopplyser.domene.register
 
 import com.ninjasquad.springmockk.MockkBean
-import io.hypersistence.utils.hibernate.type.range.Range
 import io.mockk.every
 import io.mockk.justRun
 import jakarta.persistence.EntityManager
 import no.nav.pdl.generated.enums.IdentGruppe
 import no.nav.pdl.generated.hentident.IdentInformasjon
 import no.nav.ung.deltakelseopplyser.config.DeltakerappConfig
-import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService
-import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService.Companion.rapporteringsPerioder
 import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
@@ -37,7 +34,6 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.LocalDate
-import java.time.ZonedDateTime
 import java.util.*
 
 
@@ -187,66 +183,6 @@ class UngdomsprogramregisterServiceTest {
 
         assertNotNull(hentetDto)
         assertNotNull(hentetDto.deltaker.id)
-    }
-
-    @Test
-    fun `Forventer riktig genererte rapporteringsperioder fra deltakelsesperiode`() {
-        val deltakelsePeriodInfos = listOf(
-            UngdomsprogramDeltakelseDAO(
-                id = UUID.randomUUID(),
-                deltaker = DeltakerDAO(deltakerIdent = "123"),
-                periode = Range.closed(LocalDate.parse("2024-01-15"), LocalDate.parse("2024-06-15")),
-                harSøkt = false,
-                opprettetTidspunkt = ZonedDateTime.now(),
-                endretTidspunkt = null
-            )
-        )
-
-        assertThat(deltakelsePeriodInfos).hasSize(1)
-        val rapporteringsPerioder = deltakelsePeriodInfos[0].rapporteringsPerioder()
-        assertThat(rapporteringsPerioder).hasSize(6)
-
-        assertThat(rapporteringsPerioder.first().fraOgMed).isEqualTo(LocalDate.parse("2024-01-15"))
-        assertThat(rapporteringsPerioder.first().tilOgMed).isEqualTo(LocalDate.parse("2024-01-31"))
-
-        assertThat(rapporteringsPerioder[1].fraOgMed).isEqualTo(LocalDate.parse("2024-02-01"))
-        assertThat(rapporteringsPerioder[1].tilOgMed).isEqualTo(LocalDate.parse("2024-02-29"))
-
-        assertThat(rapporteringsPerioder[2].fraOgMed).isEqualTo(LocalDate.parse("2024-03-01"))
-        assertThat(rapporteringsPerioder[2].tilOgMed).isEqualTo(LocalDate.parse("2024-03-31"))
-
-        assertThat(rapporteringsPerioder[3].fraOgMed).isEqualTo(LocalDate.parse("2024-04-01"))
-        assertThat(rapporteringsPerioder[3].tilOgMed).isEqualTo(LocalDate.parse("2024-04-30"))
-
-        assertThat(rapporteringsPerioder[4].fraOgMed).isEqualTo(LocalDate.parse("2024-05-01"))
-        assertThat(rapporteringsPerioder[4].tilOgMed).isEqualTo(LocalDate.parse("2024-05-31"))
-
-        assertThat(rapporteringsPerioder.last().fraOgMed).isEqualTo(LocalDate.parse("2024-06-01"))
-        assertThat(rapporteringsPerioder.last().tilOgMed).isEqualTo(LocalDate.parse("2024-06-15"))
-    }
-
-    @Test
-    fun `Forvent at rapporteringsperiode genereres til slutten av startdatoens måned dersom tom dato ikke er satt`() {
-        val idag = LocalDate.now()
-        val toMånederSiden = idag.minusMonths(2)
-        val periodeFra = toMånederSiden
-        val deltakelsePeriodInfos = listOf(
-            UngdomsprogramDeltakelseDAO(
-                id = UUID.randomUUID(),
-                deltaker = DeltakerDAO(deltakerIdent = "123"),
-                periode = Range.closedInfinite(periodeFra),
-                harSøkt = false,
-                opprettetTidspunkt = ZonedDateTime.now(),
-                endretTidspunkt = null
-            )
-        )
-
-        assertThat(deltakelsePeriodInfos).hasSize(1)
-        val rapporteringsPerioder = deltakelsePeriodInfos[0].rapporteringsPerioder()
-        assertThat(rapporteringsPerioder).hasSize(1)
-
-        assertThat(rapporteringsPerioder.first().fraOgMed).isEqualTo(toMånederSiden)
-        assertThat(rapporteringsPerioder.first().tilOgMed).isEqualTo(toMånederSiden.withDayOfMonth(toMånederSiden.lengthOfMonth()))
     }
 
     @Test

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/DeltakelsePeriodInfo.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/DeltakelsePeriodInfo.kt
@@ -11,5 +11,4 @@ data class DeltakelsePeriodInfo(
     @JsonProperty("tilOgMed") val tilOgMed: LocalDate? = null,
     @JsonProperty("harSøkt") val harSøkt: Boolean,
     @JsonProperty("oppgaver") val oppgaver: List<OppgaveDTO>,
-    @JsonProperty("rapporteringsPerioder") val rapporteringsPerioder: List<RapportPeriodeinfoDTO> = emptyList(),
 )

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/RapportertInntektPeriodeinfoDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/RapportertInntektPeriodeinfoDTO.kt
@@ -3,12 +3,15 @@ package no.nav.ung.deltakelseopplyser.kontrakt.deltaker
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.util.*
 
-data class RapportPeriodeinfoDTO(
+data class RapportertInntektPeriodeinfoDTO(
+    @JsonProperty("oppgaveReferanse") val oppgaveReferanse: UUID,
     @JsonProperty("fraOgMed") val fraOgMed: LocalDate,
     @JsonProperty("tilOgMed") val tilOgMed: LocalDate,
-    @JsonProperty("harRapportert") val harRapportert: Boolean,
     @JsonProperty("arbeidstakerOgFrilansInntekt") val arbeidstakerOgFrilansInntekt: BigDecimal? = null,
     @JsonProperty("inntektFraYtelse") val inntektFraYtelse: BigDecimal? = null,
-    @JsonProperty("summertInntekt") val summertInntekt: BigDecimal? = arbeidstakerOgFrilansInntekt?.add(inntektFraYtelse ?: BigDecimal.ZERO) ?: null,
+    @JsonProperty("summertInntekt") val summertInntekt: BigDecimal? = arbeidstakerOgFrilansInntekt?.add(
+        inntektFraYtelse ?: BigDecimal.ZERO
+    ),
 )

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/RapportertInntektPeriodeinfoDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/deltaker/RapportertInntektPeriodeinfoDTO.kt
@@ -3,10 +3,8 @@ package no.nav.ung.deltakelseopplyser.kontrakt.deltaker
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.util.*
 
 data class RapportertInntektPeriodeinfoDTO(
-    @JsonProperty("oppgaveReferanse") val oppgaveReferanse: UUID,
     @JsonProperty("fraOgMed") val fraOgMed: LocalDate,
     @JsonProperty("tilOgMed") val tilOgMed: LocalDate,
     @JsonProperty("arbeidstakerOgFrilansInntekt") val arbeidstakerOgFrilansInntekt: BigDecimal? = null,

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
@@ -1,6 +1,7 @@
 package no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.RapportertInntektPeriodeinfoDTO
 import java.time.ZonedDateTime
 import java.util.*
 
@@ -9,6 +10,7 @@ data class OppgaveDTO(
     @JsonProperty("oppgavetype") val oppgavetype: Oppgavetype,
     @JsonProperty("oppgavetypeData") val oppgavetypeData: OppgavetypeDataDTO,
     @JsonProperty("bekreftelse") val bekreftelse: BekreftelseDTO?,
+    @JsonProperty("rapportertInntekt") val rapportertInntekt: RapportertInntektPeriodeinfoDTO? = null,
     @JsonProperty("status") val status: OppgaveStatus,
     @JsonProperty("opprettetDato") val opprettetDato: ZonedDateTime,
     @JsonProperty("løstDato") val løstDato: ZonedDateTime?,

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
@@ -10,7 +10,6 @@ data class OppgaveDTO(
     @JsonProperty("oppgavetype") val oppgavetype: Oppgavetype,
     @JsonProperty("oppgavetypeData") val oppgavetypeData: OppgavetypeDataDTO,
     @JsonProperty("bekreftelse") val bekreftelse: BekreftelseDTO?,
-    @JsonProperty("rapportertInntekt") val rapportertInntekt: RapportertInntektPeriodeinfoDTO? = null,
     @JsonProperty("status") val status: OppgaveStatus,
     @JsonProperty("opprettetDato") val opprettetDato: ZonedDateTime,
     @JsonProperty("løstDato") val løstDato: ZonedDateTime?,

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgaveDTO.kt
@@ -1,7 +1,6 @@
 package no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.RapportertInntektPeriodeinfoDTO
 import java.time.ZonedDateTime
 import java.util.*
 

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
@@ -1,6 +1,7 @@
 package no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.RapportertInntektPeriodeinfoDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.ProgramperiodeDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.YtelseType
 
@@ -31,7 +32,8 @@ data class RegisterinntektDTO(
 
 data class InntektsrapporteringOppgavetypeDataDTO(
     @JsonProperty("fraOgMed") val fraOgMed: LocalDate,
-    @JsonProperty("tilOgMed") val tilOgMed: LocalDate
+    @JsonProperty("tilOgMed") val tilOgMed: LocalDate,
+    @JsonProperty("rapportertInntekt") val rapportertInntekt: RapportertInntektPeriodeinfoDTO? = null,
 ): OppgavetypeDataDTO
 
 data class ArbeidOgFrilansRegisterInntektDTO(

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
@@ -1,10 +1,10 @@
 package no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonUnwrapped
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.RapportertInntektPeriodeinfoDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.periodeendring.ProgramperiodeDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.YtelseType
-
 import java.time.LocalDate
 
 @OppgavetypeDataJsonType
@@ -30,11 +30,15 @@ data class RegisterinntektDTO(
     @JsonProperty("totalInntekt") val totalInntekt: Int = totalInntektArbeidOgFrilans + totalInntektYtelse,
 )
 
-data class InntektsrapporteringOppgavetypeDataDTO(
+data class InntektsrapporteringOppgavetypeData(
     @JsonProperty("fraOgMed") val fraOgMed: LocalDate,
     @JsonProperty("tilOgMed") val tilOgMed: LocalDate,
+)
+
+data class InntektsrapporteringOppgavetypeDataDTO(
+    @JsonUnwrapped val base: InntektsrapporteringOppgavetypeData,
     @JsonProperty("rapportertInntekt") val rapportertInntekt: RapportertInntektPeriodeinfoDTO? = null,
-): OppgavetypeDataDTO
+) : OppgavetypeDataDTO
 
 data class ArbeidOgFrilansRegisterInntektDTO(
     @JsonProperty("inntekt") val inntekt: Int,


### PR DESCRIPTION
### **Behov / Bakgrunn**
Deltaker skal kunne se inntekt de har rapportert inn som følge av løst oppgave.

### **Løsning**
- Utvider `InntektsrapporteringOppgavetypeDataDTO` med nytt felt for rapportert inntekt.
- Ved mapping av oppgaver, så sjekker vi om oppgaven er av typen `RAPPORTER_INNTEKT` og status er `LØST`. Dersom dette er tilfelle, henter vi opp rapportert inntekt og mapper den på oppgavetypeData til oppgaven.

### **Andre endringer**
- Fjerner `rapporteringsperioder` da vi ikke lenger bruker dette.
- Fikser setting av navIdent ved auditlogging.
