### PR TITLE
Legger til historikk over endringer på deltakelse (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Denne tjenesten understøtter behovet for:
 
 # 5. Kode
 
+## Bruk av Hibernate Envers for endringshistorikk
+
+Applikasjonen bruker Hibernate Envers for å spore historikk på endringer gjort i deltakelse-tabellen. Dette er et bevisst unntak fra standard praksis i SiF-porteføljen, og bruken er basert på følgende spesifikke omstendigheter:
+
+* Ung-deltakelse-opplyser bruker allerede Spring og Hibernate som teknologistack, noe som skiller den fra andre applikasjoner i SiF-porteføljen
+* Hibernate Envers var en pragmatisk løsning gitt prosjektets tidsrammer, da det ga oss en fungerende endringshistorikk uten behov for egenutviklede løsninger
+* Løsningen er kun valgt fordi den integrerer naturlig med eksisterende teknologivalg i denne spesifikke applikasjonen
+
+Andre applikasjoner i SiF-porteføljen bør gjøre selvstendige vurderinger om Hibernate Envers er en passende løsning for deres behov. Det er viktig å opprettholde konsistente teknologivalg på tvers av applikasjoner i samme portefølje.
+
 # 6. Data
 
 # 7. Infrastrukturarkitektur

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-envers</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/audit/SporingsloggService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/audit/SporingsloggService.kt
@@ -18,7 +18,7 @@ class SporingsloggService(
     private val tokenValidationContextHolder: SpringTokenValidationContextHolder,
 ) {
 
-    fun loggLesetilgang(url: String, beskrivelse: String, bruker: PersonIdent) {
+    fun logg(url: String, beskrivelse: String, bruker: PersonIdent, eventClassId: EventClassId) {
         auditlogger.logg(
             Auditdata(
                 AuditdataHeader.Builder()
@@ -26,7 +26,7 @@ class SporingsloggService(
                     .medProduct(auditlogger.product)
                     .medSeverity("INFO")
                     .medName(beskrivelse)
-                    .medEventClassId(EventClassId.AUDIT_ACCESS)
+                    .medEventClassId(eventClassId)
                     .build(),
                 setOf(
                     CefField(CefFieldName.EVENT_TIME, LocalDateTime.now().toEpochSecond(ZoneOffset.UTC) * 1000L),

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseDAO.kt
@@ -36,7 +36,7 @@ class UngdomsprogramDeltakelseDAO(
     @Column(name = "periode", columnDefinition = "daterange")
     private var periode: Range<LocalDate>,
 
-    @Column(name = "søkt_tidspunkt", updatable = false)
+    @Column(name = "søkt_tidspunkt")
     var søktTidspunkt: ZonedDateTime? = null,
 ) : BaseAuditEntity() {
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
@@ -2,11 +2,12 @@ package no.nav.ung.deltakelseopplyser.domene.register
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.history.RevisionRepository
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 import java.util.*
 
-interface UngdomsprogramDeltakelseRepository : JpaRepository<UngdomsprogramDeltakelseDAO, UUID> {
+interface UngdomsprogramDeltakelseRepository : JpaRepository<UngdomsprogramDeltakelseDAO, UUID>, RevisionRepository<UngdomsprogramDeltakelseDAO, UUID, Long> {
     fun findByDeltaker_IdIn(deltakerIds: List<UUID>): List<UngdomsprogramDeltakelseDAO>
 
     fun findByIdAndDeltaker_IdIn(id: UUID, deltakerIds: List<UUID>): UngdomsprogramDeltakelseDAO?

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -4,6 +4,7 @@ import io.hypersistence.utils.hibernate.type.range.Range
 import no.nav.tms.varsel.action.Tekst
 import no.nav.tms.varsel.action.Varseltype
 import no.nav.ung.deltakelseopplyser.config.DeltakerappConfig
+import no.nav.ung.deltakelseopplyser.config.TxConfiguration.Companion.TRANSACTION_MANAGER
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService.Companion.mapToDTO
@@ -90,7 +91,7 @@ class UngdomsprogramregisterService(
             }
     }
 
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun leggTilIProgram(deltakelseOpplysningDTO: DeltakelseOpplysningDTO): DeltakelseOpplysningDTO {
         logger.info("Legger til deltaker i programmet: $deltakelseOpplysningDTO")
 
@@ -214,7 +215,7 @@ class UngdomsprogramregisterService(
         return ungdomsprogramDAOs.map { it.tilDeltakelsePeriodInfo(deltakersOppgaver) }
     }
 
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun avsluttDeltakelse(
         id: UUID,
         deltakelseOpplysningDTO: DeltakelseOpplysningDTO,
@@ -238,7 +239,7 @@ class UngdomsprogramregisterService(
         return oppdatert.mapToDTO()
     }
 
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun endreStartdato(deltakelseId: UUID, endrePeriodeDatoDTO: EndrePeriodeDatoDTO): DeltakelseOpplysningDTO {
         val eksisterende = forsikreEksistererIProgram(deltakelseId)
         logger.info("Endrer startdato for deltakelse med id $deltakelseId fra ${eksisterende.getFom()} til $endrePeriodeDatoDTO")
@@ -260,7 +261,7 @@ class UngdomsprogramregisterService(
         return oppdatertDeltakelse.mapToDTO()
     }
 
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun endreSluttdato(deltakelseId: UUID, endrePeriodeDatoDTO: EndrePeriodeDatoDTO): DeltakelseOpplysningDTO {
         val eksisterende = forsikreEksistererIProgram(deltakelseId)
         logger.info("Endrer sluttdato for deltakelse med id $deltakelseId fra ${eksisterende.getTom()} til $endrePeriodeDatoDTO")

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
@@ -6,6 +6,7 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.ung.deltakelseopplyser.config.Issuers.TOKEN_X
+import no.nav.ung.deltakelseopplyser.config.TxConfiguration.Companion.TRANSACTION_MANAGER
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
@@ -129,7 +130,7 @@ class UngdomsprogramRegisterDeltakerController(
     @GetMapping("/oppgave/{oppgaveReferanse}/åpnet", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Markerer en oppgave som åpnet")
     @ResponseStatus(HttpStatus.OK)
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun markerOppgaveSomÅpnet(@PathVariable oppgaveReferanse: UUID): OppgaveDTO {
         val (deltaker, oppgave) = hentDeltakerOppgave(oppgaveReferanse)
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -2,13 +2,13 @@ package no.nav.ung.deltakelseopplyser.domene.register.ungsak
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import jakarta.transaction.Transactional
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
 import no.nav.tms.varsel.action.Tekst
 import no.nav.tms.varsel.action.Varseltype
 import no.nav.ung.deltakelseopplyser.config.DeltakerappConfig
 import no.nav.ung.deltakelseopplyser.config.Issuers
+import no.nav.ung.deltakelseopplyser.config.TxConfiguration.Companion.TRANSACTION_MANAGER
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.ArbeidOgFrilansRegisterInntektDAO
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.ErrorResponseException
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -73,7 +74,7 @@ class OppgaveUngSakController(
     @PostMapping("/avbryt", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Avbryter oppgave")
     @ResponseStatus(HttpStatus.OK)
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun avbrytOppgave(@RequestBody oppgaveReferanse: UUID) {
         tilgangskontrollService.krevSystemtilgang()
         logger.info("Avbryter oppgave med referanse $oppgaveReferanse")
@@ -98,7 +99,7 @@ class OppgaveUngSakController(
     @PostMapping("/utløpt", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Setter oppgave til utløpt")
     @ResponseStatus(HttpStatus.OK)
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun utløperOppgave(@RequestBody oppgaveReferanse: UUID) {
         tilgangskontrollService.krevSystemtilgang()
         logger.info("Utløper oppgave med referanse $oppgaveReferanse")
@@ -123,7 +124,7 @@ class OppgaveUngSakController(
     @PostMapping("/utløpt/forTypeOgPeriode", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Setter oppgave til utløpt for type og periode")
     @ResponseStatus(HttpStatus.OK)
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun utløperOppgaveForTypeOgPeriode(@RequestBody settTilUtløptDTO: SettTilUtløptDTO) {
         tilgangskontrollService.krevSystemtilgang()
         logger.info("Utløper oppgave av type: ${settTilUtløptDTO.oppgavetype} med periode [${settTilUtløptDTO.fomDato} - ${settTilUtløptDTO.tomDato}]")
@@ -158,7 +159,7 @@ class OppgaveUngSakController(
     @PostMapping("/opprett/kontroll/registerinntekt", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Oppretter oppgave for kontroll av registerinntekt")
     @ResponseStatus(HttpStatus.OK)
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun opprettOppgaveForKontrollAvRegisterinntekt(@RequestBody opprettOppgaveDto: RegisterInntektOppgaveDTO): OppgaveDTO {
         tilgangskontrollService.krevSystemtilgang()
         logger.info("Oppretter oppgave for kontroll av registerinntekt")
@@ -213,7 +214,7 @@ class OppgaveUngSakController(
     @PostMapping("/opprett/endre/programperiode", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Oppretter oppgave for endret programperiode")
     @ResponseStatus(HttpStatus.OK)
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun opprettOppgaveForEndretProgramperiode(@RequestBody endretProgramperiodeOppgaveDTO: EndretProgamperiodeOppgaveDTO): OppgaveDTO {
         tilgangskontrollService.krevSystemtilgang()
         logger.info("Oppretter oppgave for endret programperiode med referanse ${endretProgramperiodeOppgaveDTO.oppgaveReferanse}")
@@ -255,7 +256,7 @@ class OppgaveUngSakController(
     @PostMapping("/opprett/inntektsrapportering", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Oppretter oppgave for inntektsrapportering")
     @ResponseStatus(HttpStatus.OK)
-    @Transactional
+    @Transactional(TRANSACTION_MANAGER)
     fun opprettOppgaveForInntektsrapportering(@RequestBody opprettInntektsrapporteringOppgaveDTO: InntektsrapporteringOppgaveDTO): OppgaveDTO {
         tilgangskontrollService.krevSystemtilgang()
         logger.info("Oppretter oppgave for kontroll av registerinntekt")

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramDeltakerInfoVeilederController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramDeltakerInfoVeilederController.kt
@@ -2,6 +2,7 @@ package no.nav.ung.deltakelseopplyser.domene.register.veileder
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import no.nav.k9.felles.log.audit.EventClassId
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
 import no.nav.sif.abac.kontrakt.abac.BeskyttetRessursActionAttributt.READ
@@ -37,10 +38,11 @@ class UngdomsprogramDeltakerInfoVeilederController(
         tilgangskontrollService.krevAnsattTilgang(READ, listOf(PersonIdent.fra(deltakerDTO.deltakerIdent)))
         return deltakerService.hentDeltakerInfo(deltakerIdent = deltakerDTO.deltakerIdent)
             .also {
-                sporingsloggService.loggLesetilgang(
+                sporingsloggService.logg(
                     "/deltaker",
                     "Hent personalia for en deltaker",
-                    PersonIdent.fra(deltakerDTO.deltakerIdent)
+                    PersonIdent.fra(deltakerDTO.deltakerIdent),
+                    EventClassId.AUDIT_ACCESS
                 )
             }
     }
@@ -54,10 +56,11 @@ class UngdomsprogramDeltakerInfoVeilederController(
         tilgangskontrollService.krevAnsattTilgang(READ, listOf(personIdent))
         return deltakerInfo
             .also {
-                sporingsloggService.loggLesetilgang(
+                sporingsloggService.logg(
                     "/deltaker/{id}",
                     "Hent personalia for en deltaker gitt UUID",
-                    personIdent
+                    personIdent,
+                    EventClassId.AUDIT_ACCESS
                 )
             }
     }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramRegisterVeilederController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramRegisterVeilederController.kt
@@ -2,6 +2,7 @@ package no.nav.ung.deltakelseopplyser.domene.register.veileder
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import no.nav.k9.felles.log.audit.EventClassId
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.RequiredIssuers
 import no.nav.sif.abac.kontrakt.abac.BeskyttetRessursActionAttributt.*
@@ -11,6 +12,7 @@ import no.nav.ung.deltakelseopplyser.config.Issuers
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseHistorikkDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.veileder.DeltakelseInnmeldingDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.veileder.DeltakelseUtmeldingDTO
@@ -50,7 +52,14 @@ class UngdomsprogramRegisterVeilederController(
             oppgaver = listOf()
         )
 
-        return registerService.leggTilIProgram(deltakelseOpplysningDTO)
+        return registerService.leggTilIProgram(deltakelseOpplysningDTO).also {
+            sporingsloggService.logg(
+                "/deltaker/innmelding",
+                "Meldte inn deltaker med id ${deltakelseInnmeldingDTO.deltakerIdent}",
+                PersonIdent.fra(deltakelseInnmeldingDTO.deltakerIdent),
+                EventClassId.AUDIT_CREATE
+            )
+        }
     }
 
     @PutMapping(
@@ -70,7 +79,14 @@ class UngdomsprogramRegisterVeilederController(
             listOf(PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent))
         )
         val utmeldtDeltakelse = eksisterendeDeltakelse.copy(tilOgMed = deltakelseUtmeldingDTO.utmeldingsdato)
-        return registerService.avsluttDeltakelse(deltakelseId, utmeldtDeltakelse)
+        return registerService.avsluttDeltakelse(deltakelseId, utmeldtDeltakelse).also {
+            sporingsloggService.logg(
+                "/deltakelse/{deltakelseId}/avslutt",
+                "Avsluttet deltakelse med id $deltakelseId",
+                PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent),
+                EventClassId.AUDIT_UPDATE
+            )
+        }
     }
 
     @PutMapping(
@@ -89,7 +105,14 @@ class UngdomsprogramRegisterVeilederController(
             UPDATE,
             listOf(PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent))
         )
-        return registerService.endreStartdato(deltakelseId, endrePeriodeDatoDTO)
+        return registerService.endreStartdato(deltakelseId, endrePeriodeDatoDTO).also {
+            sporingsloggService.logg(
+                "/deltakelse/{deltakelseId}/endre/startdato",
+                "Endret startdato for deltakelse med id $deltakelseId",
+                PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent),
+                EventClassId.AUDIT_UPDATE
+            )
+        }
     }
 
     @PutMapping(
@@ -108,7 +131,14 @@ class UngdomsprogramRegisterVeilederController(
             UPDATE,
             listOf(PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent))
         )
-        return registerService.endreSluttdato(deltakelseId, endrePeriodeDatoDTO)
+        return registerService.endreSluttdato(deltakelseId, endrePeriodeDatoDTO).also {
+            sporingsloggService.logg(
+                "/deltakelse/{deltakelseId}/endre/sluttdato",
+                "Endret sluttdato for deltakelse med id $deltakelseId",
+                PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent),
+                EventClassId.AUDIT_UPDATE
+            )
+        }
     }
 
     @GetMapping(
@@ -123,12 +153,32 @@ class UngdomsprogramRegisterVeilederController(
         tilgangskontrollService.krevAnsattTilgang(READ, personIdenter)
         return deltakelser
             .also {
-                sporingsloggService.loggLesetilgang(
+                sporingsloggService.logg(
                     "/deltaker/deltakerId/deltakelser",
                     "Hent alle deltakelser for en deltaker",
-                    personIdenter.first()
+                    personIdenter.first(),
+                    EventClassId.AUDIT_ACCESS
                 )
             }
+    }
+
+    @GetMapping(
+        "/deltakelse/{deltakelseId}/historikk", produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun deltakelseHistorikk(@PathVariable deltakelseId: UUID): List<DeltakelseHistorikkDTO> {
+        val eksisterendeDeltakelse = registerService.hentFraProgram(deltakelseId)
+        tilgangskontrollService.krevAnsattTilgang(
+            READ,
+            listOf(PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent))
+        )
+        return registerService.deltakelseHistorikk(deltakelseId).also {
+            sporingsloggService.logg(
+                "/deltakelse/{deltakelseId}/historikk",
+                "Hent historikk for deltakelse med id $deltakelseId",
+                PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent),
+                EventClassId.AUDIT_ACCESS
+            )
+        }
     }
 
     @DeleteMapping("/deltakelse/{deltakelseId}/fjern")
@@ -140,6 +190,13 @@ class UngdomsprogramRegisterVeilederController(
             UPDATE,
             listOf(PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent))
         )
-        registerService.fjernFraProgram(deltakelseId)
+        registerService.fjernFraProgram(deltakelseId).also {
+            sporingsloggService.logg(
+                "/deltakelse/{deltakelseId}/fjern",
+                "Fjernet deltakelse med id $deltakelseId",
+                PersonIdent.fra(eksisterendeDeltakelse.deltaker.deltakerIdent),
+                EventClassId.AUDIT_UPDATE
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/AuditorAwareImpl.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/AuditorAwareImpl.kt
@@ -1,0 +1,89 @@
+package no.nav.ung.deltakelseopplyser.historikk
+
+import no.nav.security.token.support.core.configuration.MultiIssuerConfiguration
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import no.nav.ung.deltakelseopplyser.config.Issuers
+import no.nav.ung.deltakelseopplyser.historikk.AuditorAwareImpl.Companion.AUDITOR_AWARE_IMPL_BEAN_NAME
+import no.nav.ung.deltakelseopplyser.utils.gyldigToken
+import no.nav.ung.deltakelseopplyser.utils.navIdent
+import no.nav.ung.deltakelseopplyser.utils.personIdent
+import org.springframework.data.domain.AuditorAware
+import org.springframework.stereotype.Component
+import java.util.*
+
+/**
+ * Spring Data JPA krever en implementasjon av AuditorAware for å kunne sette auditor.
+ * Vi bruker dette til å sette inn hvem som har opprettet og endret en entitet.
+ *
+ * Vi bruker SpringTokenValidationContextHolder for å hente ut auditor fra token.
+ */
+@Component(value = AUDITOR_AWARE_IMPL_BEAN_NAME)
+class AuditorAwareImpl(
+    private val tokenValidationContextHolder: SpringTokenValidationContextHolder,
+    private val multiIssuerConfiguration: MultiIssuerConfiguration,
+) : AuditorAware<String> {
+
+    companion object{
+        const val AUDITOR_AWARE_IMPL_BEAN_NAME = "auditorAwareImpl"
+    }
+
+    override fun getCurrentAuditor(): Optional<String> {
+        val auditor = tokenValidationContextHolder.auditor()
+        return Optional.of(auditor)
+    }
+
+    private fun SpringTokenValidationContextHolder.auditor(): String {
+        if (!finnesGyldigTokenIContext()) {
+            return systemAuditor()
+        }
+
+        val jwtToken = gyldigToken()
+
+        return when {
+            jwtToken.erTokenxIssuer() -> {
+                deltakerAuditor()
+            }
+
+            jwtToken.erAzureIssuer() -> {
+                when {
+                    jwtToken.erAzureSystemToken() -> systemAuditor()
+                    else -> veilederAuditor()
+                }
+            }
+
+            else -> {
+                systemAuditor()
+            }
+        }
+    }
+
+    private fun systemAuditor() = "system"
+
+    private fun SpringTokenValidationContextHolder.veilederAuditor() = "${navIdent()} (veileder)"
+
+    private fun SpringTokenValidationContextHolder.deltakerAuditor() = "${personIdent()} (deltaker)"
+
+    /**
+     * Sjekker om det finnes en gyldig token i context.
+     */
+    private fun finnesGyldigTokenIContext(): Boolean {
+        return runCatching { tokenValidationContextHolder.getTokenValidationContext() }
+            .fold(
+                onSuccess = { it.firstValidToken != null },
+                onFailure = { false }
+            )
+    }
+
+    private fun JwtToken.erTokenxIssuer(): Boolean {
+        return multiIssuerConfiguration.issuers[Issuers.TOKEN_X]?.metadata?.issuer?.value == issuer
+    }
+
+    private fun JwtToken.erAzureSystemToken(): Boolean {
+        return erAzureIssuer() && jwtTokenClaims.getStringClaim("idtyp") == "app"
+    }
+
+    private fun JwtToken.erAzureIssuer(): Boolean {
+        return multiIssuerConfiguration.issuers[Issuers.AZURE]?.metadata?.issuer?.value == issuer
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/BaseAuditEntity.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/BaseAuditEntity.kt
@@ -1,0 +1,41 @@
+package no.nav.ung.deltakelseopplyser.historikk
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.hibernate.envers.Audited
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+
+/**
+ * Baseentitet for alle entiteter som skal ha historikk.
+ * Må huske å annotere den klassen eller felter i den med @Audited.
+ *
+ * @CreatedBy og @LastModifiedBy for å sette inn hvem som har opprettet og endret en entitet.
+ * @CreatedDate og @LastModifiedDate for å sette inn når en entitet ble opprettet og endret.
+ */
+@Audited
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseAuditEntity {
+
+    @CreatedBy
+    @Column(name = "opprettet_av", updatable = false)
+    var opprettetAv: String? = null
+
+    @CreatedDate
+    @Column(name = "opprettet_tidspunkt", updatable = false)
+    var opprettetTidspunkt: Instant = Instant.now()
+
+    @LastModifiedDate
+    @Column(name = "endret_tidspunkt")
+    var endretTidspunkt: Instant? = null
+
+    @LastModifiedBy
+    @Column(name = "endret_av")
+    var endretAv: String? = null
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/PersistenceConfiguration.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/PersistenceConfiguration.kt
@@ -1,0 +1,9 @@
+package no.nav.ung.deltakelseopplyser.historikk
+
+import no.nav.ung.deltakelseopplyser.historikk.AuditorAwareImpl.Companion.AUDITOR_AWARE_IMPL_BEAN_NAME
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = AUDITOR_AWARE_IMPL_BEAN_NAME)
+class PersistenceConfiguration

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenUtils.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenUtils.kt
@@ -1,5 +1,6 @@
 package no.nav.ung.deltakelseopplyser.utils
 
+import no.nav.security.token.support.core.jwt.JwtToken
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 
 object TokenClaims {
@@ -14,25 +15,13 @@ object TokenClaims {
 }
 
 fun SpringTokenValidationContextHolder.personIdent(): String {
-    val jwtToken = getTokenValidationContext().firstValidToken
-        ?: throw IllegalStateException("Ingen gyldige tokens i Authorization headeren")
+    val jwtToken = gyldigToken()
 
     val pid = jwtToken.jwtTokenClaims.getStringClaim(TokenClaims.CLAIM_PID)
     val sub = jwtToken.jwtTokenClaims.getStringClaim(TokenClaims.CLAIM_SUB)
 
     return when {
         !pid.isNullOrBlank() -> pid
-        !sub.isNullOrBlank() -> sub
-        else -> throw IllegalStateException("Ugyldig token. Token inneholdt verken sub eller pid claim")
-    }
-}
-
-fun SpringTokenValidationContextHolder.subject(): String {
-    val jwtToken = getTokenValidationContext().firstValidToken
-        ?: throw IllegalStateException("Ingen gyldige tokens i Authorization headeren")
-
-    val sub = jwtToken.jwtTokenClaims.getStringClaim(TokenClaims.CLAIM_SUB)
-    return when {
         !sub.isNullOrBlank() -> sub
         else -> throw IllegalStateException("Ugyldig token. Token inneholdt verken sub eller pid claim")
     }
@@ -48,5 +37,9 @@ fun SpringTokenValidationContextHolder.navIdent(): String {
         else -> throw IllegalStateException("Ugyldig token. Token inneholdt ikke ${TokenClaims.NAV_IDENT} claim")
     }
 }
+
+fun SpringTokenValidationContextHolder.gyldigToken(): JwtToken =
+    (getTokenValidationContext().firstValidToken
+        ?: throw IllegalStateException("Ingen gyldige tokens i Authorization headeren"))
 
 

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -6,7 +6,15 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
+    properties:
+      # https://docs.jboss.org/hibernate/orm/4.3/devguide/en-US/html/ch15.html#envers-configuration
+      org.hibernate.envers:
+        audit_strategy: org.hibernate.envers.strategy.ValidityAuditStrategy
+        audit_strategy_validity_store_revend_timestamp: true
+        store_data_at_delete: true
+        audit_table_suffix: _historikk
+
   datasource:
     hikari:
       connection-test-query: SELECT 1

--- a/app/src/main/resources/db/migration/V12__deltakelse_historikk.sql
+++ b/app/src/main/resources/db/migration/V12__deltakelse_historikk.sql
@@ -1,0 +1,34 @@
+ALTER TABLE IF EXISTS ungdomsprogram_deltakelse
+    ADD COLUMN opprettet_av TEXT NULL,
+    ADD COLUMN endret_av    TEXT NULL;
+
+CREATE SEQUENCE IF NOT EXISTS revinfo_seq
+    START WITH 1
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE TABLE IF NOT EXISTS revinfo
+(
+    rev      INTEGER PRIMARY KEY NOT NULL, -- Version number.
+    revtstmp BIGINT                        -- Epoch timestamp of the version number.
+);
+
+CREATE TABLE IF NOT EXISTS ungdomsprogram_deltakelse_historikk
+(
+    -- Påkrevde felt for historikk
+    id                  UUID,
+    rev                 INTEGER REFERENCES revinfo (rev), -- Versjonnummeret for entiteten.
+    revend              INTEGER REFERENCES revinfo (rev), -- Versjonnummeret for neste versjon etter at entiten blir oppdatert.
+    revtype             SMALLINT,                         -- Type endring, 1=insert, 2=update, 3=delete.
+    revend_tstmp        TIMESTAMP,                        -- Tidsspunkt for neste versjon etter at entiteten blir oppdatert.
+    -- Påkrevde felt historikk
+
+    periode             DATERANGE NOT NULL,
+    søkt_tidspunkt      TIMESTAMP NULL,
+    opprettet_tidspunkt TIMESTAMP,
+    endret_tidspunkt    TIMESTAMP,
+    opprettet_av        TEXT,
+    endret_av           TEXT
+);

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
@@ -57,10 +57,7 @@ import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import java.util.*
 
-@EnableMockOAuth2Server
-@ExtendWith(SpringExtension::class)
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class OppgaveServiceTest : AbstractIntegrationTest() {
 
     @Autowired

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenTestUtils.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/utils/TokenTestUtils.kt
@@ -9,7 +9,7 @@ import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.ung.deltakelseopplyser.config.Issuers.TOKEN_X
 
 object TokenTestUtils {
-    const val MOCK_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    const val MOCK_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaXNzIjoidG9rZW54IiwiaWF0IjoxNTE2MjM5MDIyfQ.LVLy4KvnogeEqfc3V0AYHoNDATNkqqUSzQS43zhgYeo"
 
     fun MockOAuth2Server.hentToken(
         subject: String = "12345678910",

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/register/DeltakelseHistorikkDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/register/DeltakelseHistorikkDTO.kt
@@ -1,0 +1,18 @@
+package no.nav.ung.deltakelseopplyser.kontrakt.register
+
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import java.util.*
+
+data class DeltakelseHistorikkDTO(
+    val revisjonstype: Revisjonstype,
+    val revisjonsnummer: Long,
+    val id: UUID,
+    val fom: LocalDate,
+    val tom: LocalDate?,
+    val opprettetAv: String?,
+    val opprettetTidspunkt: ZonedDateTime,
+    val endretAv: String,
+    val endretTidspunkt: ZonedDateTime,
+    val søktTidspunkt: ZonedDateTime?,
+)

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/register/Revisjonstype.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/register/Revisjonstype.kt
@@ -1,0 +1,8 @@
+package no.nav.ung.deltakelseopplyser.kontrakt.register
+
+enum class Revisjonstype {
+    OPPRETTET,
+    ENDRET,
+    SLETTET,
+    UKJENT
+}


### PR DESCRIPTION
### **Behov / Bakgrunn**
Veileder trenger å kunne se endringer som er gjort på ungdomsprogramdeltakelsen.

Godkjent her: #98 

### **Løsning**
- Bruker `spring-data-envers` til å bootstrappe loggføring av endringer på deltakelse.
- Implementerer `AuditorAware` interface (`AuditorAwareImpl`) for å kunne loggføre hvem som har gjort endringer på en deltakelse.
- Oppretter en `BaseAuditEntity` som `UngdomsprogramDeltakelseDAO` extender for å sette felles felt som opprettetAv, endretAv osv.
- Migrerer til nytt databaseversjon som legger til nye kolonner på deltakelse tabellen, og oppretter nødvendige sekvenser og tabeller for historikk.
- Setter `jpa.hibernate.ddl-auto: validate` for å validere at tabeller opprettes via flyway.
- Legger til endepunkt og servicemetode for å kunne hente historikk på en spesifikk deltakelse, gitt dens id.

### **Andre endringer**
- Legger til token utils for å utlede issuer på token.
- Refaktorerer `SporingsloggService` til å ta inn `EventClassId` som parameter ved logging.
- Legger til sporingslogg (audit) ved andre veileder operasjoner som manglet.

### **Skjermbilde**
#### Resultat test dev.
```json
[
  {
    "revisjonstype": "OPPRETTET",
    "revisjonsnummer": 5,
    "id": "82303e99-4625-450f-91bb-05a0e8f00ee5",
    "fom": "2025-05-23",
    "tom": null,
    "opprettetAv": "Z994376 (veileder)",
    "opprettetTidspunkt": "2025-05-23T10:39:57.587840Z",
    "endretAv": "Z994376 (veileder)",
    "endretTidspunkt": "2025-05-23T10:39:57.587840Z",
    "søktTidspunkt": null
  },
  {
    "revisjonstype": "ENDRET",
    "revisjonsnummer": 52,
    "id": "82303e99-4625-450f-91bb-05a0e8f00ee5",
    "fom": "2025-05-26",
    "tom": null,
    "opprettetAv": "Z994376 (veileder)",
    "opprettetTidspunkt": "2025-05-23T10:39:57.587840Z",
    "endretAv": "Z994376 (veileder)",
    "endretTidspunkt": "2025-05-23T10:54:54.114674Z",
    "søktTidspunkt": null
  },
  {
    "revisjonstype": "ENDRET",
    "revisjonsnummer": 102,
    "id": "82303e99-4625-450f-91bb-05a0e8f00ee5",
    "fom": "2025-05-26",
    "tom": "2025-06-23",
    "opprettetAv": "Z994376 (veileder)",
    "opprettetTidspunkt": "2025-05-23T10:39:57.587840Z",
    "endretAv": "Z994376 (veileder)",
    "endretTidspunkt": "2025-05-23T10:55:26.677635Z",
    "søktTidspunkt": null
  }
]
```