### PR TITLE
Aktiverer Mikrofrontend ved mottatt søknad.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -184,6 +184,11 @@
             <artifactId>kotlin-builder</artifactId>
             <version>${tms-kotlin-builder.version}</version>
         </dependency>
+        <dependency>
+            <groupId>no.nav.tms.mikrofrontend.selector</groupId>
+            <artifactId>builder</artifactId>
+            <version>3.0.0</version>
+        </dependency>
         <!-- Mine Sider (Nav.no) -->
 
         <!-- Kotlin -->

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/RapportertInntektHåndtererService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/RapportertInntektHåndtererService.kt
@@ -6,7 +6,7 @@ import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.kafka.UngdomsytelseRapportertInntekt
 import no.nav.ung.deltakelseopplyser.domene.inntekt.repository.RapportertInntektRepository
 import no.nav.ung.deltakelseopplyser.domene.inntekt.repository.UngRapportertInntektDAO
-import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -16,7 +16,7 @@ import java.util.*
 class RapportertInntektHåndtererService(
     private val rapportertInntektRepository: RapportertInntektRepository,
     private val deltakerService: DeltakerService,
-    private val mineSiderVarselService: MineSiderVarselService
+    private val mineSiderService: MineSiderService
 ) {
     private companion object {
         private val logger = LoggerFactory.getLogger(RapportertInntektHåndtererService::class.java)
@@ -40,7 +40,7 @@ class RapportertInntektHåndtererService(
         oppgave.markerSomLøst()
 
         logger.info("Deaktiverer oppgave med oppgaveReferanse=$oppgaveReferanse da den er løst")
-        mineSiderVarselService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
+        mineSiderService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
 
         logger.info("Lagrer rapportert inntekt med journalpostId: {}", rapportertInntektTopicEntry.journalpostId)
         rapportertInntektRepository.save(rapportertInntektTopicEntry.somRapportertInntektDAO())

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MicrofrontendStatus.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MicrofrontendStatus.kt
@@ -1,0 +1,5 @@
+package no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend
+
+enum class MicrofrontendStatus {
+    ENABLE, DISABLE
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MikrofrontendDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MikrofrontendDAO.kt
@@ -1,0 +1,62 @@
+package no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.annotations.UpdateTimestamp
+import org.hibernate.type.SqlTypes
+import org.springframework.data.annotation.CreatedDate
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.util.*
+
+@Entity
+@Table(
+    name = "mikrofrontend",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_mikrofrontend_deltaker_mf",
+            columnNames = ["deltaker_id", "mikrofrontend_id"]
+        )
+    ]
+)
+class MikrofrontendDAO(
+    @Id
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "id")
+    val id: UUID = UUID.randomUUID(),
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "deltaker_id", referencedColumnName = "id", nullable = false)
+    val deltaker: DeltakerDAO,
+
+    @Column(
+        name = "mikrofrontend_id",
+        nullable = false,
+        length = 100
+    ) val mikrofrontendId: String,
+
+    @Column(
+        name = "status",
+        nullable = false,
+        length = 10
+    ) @Enumerated(EnumType.STRING)
+    val status: MicrofrontendStatus,
+
+    @Column(name = "opprettet")
+    @CreatedDate
+    val opprettet: ZonedDateTime? = null,
+
+    @Column(name = "endret")
+    @UpdateTimestamp
+    val endret: LocalDateTime? = null
+)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MikrofrontendId.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MikrofrontendId.kt
@@ -1,0 +1,17 @@
+package no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend
+
+/**
+ * MicrofrontendId avtales på forhånd med team-personbruker.
+ */
+
+enum class MikrofrontendId(val id: String) {
+
+    UNGDOMSPROGRAMYTELSE_INNSYN("ungdomsprogramytelse-innsyn");
+
+    companion object {
+        private val idMap = values().associateBy(MikrofrontendId::id)
+
+        fun fraId(id: String): MikrofrontendId =
+            idMap[id] ?: throw IllegalArgumentException("Ukjent MikrofrontendId id='$id'")
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MikrofrontendRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MikrofrontendRepository.kt
@@ -1,0 +1,6 @@
+package no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface MikrofrontendRepository : JpaRepository<MikrofrontendDAO, UUID>

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MikrofrontendService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/minside/mikrofrontend/MikrofrontendService.kt
@@ -1,0 +1,24 @@
+package no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend
+
+import no.nav.tms.microfrontend.Sensitivitet
+import no.nav.ung.deltakelseopplyser.config.TxConfiguration
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MikrofrontendService(
+    private val mikrofrontendRepository: MikrofrontendRepository,
+    private val mineSiderService: MineSiderService,
+) {
+
+    @Transactional(transactionManager = TxConfiguration.TRANSACTION_MANAGER, rollbackFor = [Exception::class])
+    fun sendOgLagre(mikrofrontendDAO: MikrofrontendDAO) {
+        mineSiderService.aktiverMikrofrontend(
+            deltakerIdent = mikrofrontendDAO.deltaker.deltakerIdent,
+            mikrofrontendId = MikrofrontendId.fraId(mikrofrontendDAO.mikrofrontendId),
+            sensitivitet = Sensitivitet.HIGH,
+        )
+        mikrofrontendRepository.save(mikrofrontendDAO)
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
@@ -8,7 +8,7 @@ import no.nav.ung.deltakelseopplyser.config.TxConfiguration.Companion.TRANSACTIO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.oppgave.kafka.UngdomsytelseOppgavebekreftelse
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
-import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -18,7 +18,7 @@ import java.util.*
 @Service
 class OppgaveService(
     private val deltakerService: DeltakerService,
-    private val mineSiderVarselService: MineSiderVarselService
+    private val mineSiderService: MineSiderService
 ) {
     private companion object {
         private val logger = LoggerFactory.getLogger(OppgaveService::class.java)
@@ -51,7 +51,7 @@ class OppgaveService(
         deltakerService.oppdaterDeltaker(deltaker)
 
         logger.info("Deaktiverer oppgave med oppgaveReferanse=$oppgaveReferanse da den er løst")
-        mineSiderVarselService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
+        mineSiderService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
     }
 
     private fun forsikreRiktigOppgaveBekreftelse(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -11,7 +11,7 @@ import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService.Companion.m
 import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO.Companion.tilDTO
-import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngSakService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakelsePeriodInfo
@@ -46,7 +46,7 @@ class UngdomsprogramregisterService(
     private val ungSakService: UngSakService,
     private val pdlService: PdlService,
     private val rapportertInntektService: RapportertInntektService,
-    private val mineSiderVarselService: MineSiderVarselService,
+    private val mineSiderService: MineSiderService,
     private val deltakerappConfig: DeltakerappConfig,
 ) {
     companion object {
@@ -111,7 +111,7 @@ class UngdomsprogramregisterService(
         ungdomsprogramDAO: UngdomsprogramDeltakelseDAO,
         deltakerDAO: DeltakerDAO,
     ) {
-        mineSiderVarselService.opprettVarsel(
+        mineSiderService.opprettVarsel(
             varselId = ungdomsprogramDAO.id.toString(),
             deltakerIdent = deltakerDAO.deltakerIdent,
             tekster = listOf(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/deltaker/UngdomsprogramRegisterDeltakerController.kt
@@ -12,7 +12,7 @@ import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO.Companion.tilDTO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
-import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakelsePeriodInfo
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
@@ -45,7 +45,7 @@ import java.util.*
 class UngdomsprogramRegisterDeltakerController(
     private val registerService: UngdomsprogramregisterService,
     private val deltakerService: DeltakerService,
-    private val mineSiderVarselService: MineSiderVarselService,
+    private val mineSiderService: MineSiderService,
     private val tokenValidationContextHolder: SpringTokenValidationContextHolder,
 ) {
 
@@ -137,7 +137,7 @@ class UngdomsprogramRegisterDeltakerController(
         val oppdatertOppgave = oppgave.markerSomÅpnet()
         deltakerService.oppdaterDeltaker(deltaker)
 
-        mineSiderVarselService.deaktiverOppgave(oppgaveReferanse.toString())
+        mineSiderService.deaktiverOppgave(oppgaveReferanse.toString())
 
         return oppdatertOppgave.tilDTO()
     }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -22,7 +22,7 @@ import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.ProgramperiodeDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.RegisterinntektDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.YtelseRegisterInntektDAO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
-import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
@@ -63,7 +63,7 @@ class OppgaveUngSakController(
     private val tilgangskontrollService: TilgangskontrollService,
     private val deltakerService: DeltakerService,
     private val deltakelseRepository: UngdomsprogramDeltakelseRepository,
-    private val mineSiderVarselService: MineSiderVarselService,
+    private val mineSiderService: MineSiderService,
     private val deltakerappConfig: DeltakerappConfig,
 ) {
 
@@ -93,7 +93,7 @@ class OppgaveUngSakController(
         deltakerService.oppdaterDeltaker(deltaker)
 
         logger.info("Deaktiverer oppgave med oppgaveReferanse $oppgaveReferanse på min side")
-        mineSiderVarselService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
+        mineSiderService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
     }
 
     @PostMapping("/utløpt", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -118,7 +118,7 @@ class OppgaveUngSakController(
         deltakerService.oppdaterDeltaker(deltaker)
 
         logger.info("Deaktiverer oppgave med oppgaveReferanse $oppgaveReferanse på min side")
-        mineSiderVarselService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
+        mineSiderService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
     }
 
     @PostMapping("/utløpt/forTypeOgPeriode", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -152,7 +152,7 @@ class OppgaveUngSakController(
             deltakerService.oppdaterDeltaker(deltaker)
 
             logger.info("Deaktiverer oppgave på min side")
-            mineSiderVarselService.deaktiverOppgave(uløstOppgaveISammePeriode.oppgaveReferanse.toString())
+            mineSiderService.deaktiverOppgave(uløstOppgaveISammePeriode.oppgaveReferanse.toString())
         }
     }
 
@@ -318,7 +318,7 @@ class OppgaveUngSakController(
         deltaker.leggTilOppgave(nyOppgave)
         deltakerService.oppdaterDeltaker(deltaker)
 
-        mineSiderVarselService.opprettVarsel(
+        mineSiderService.opprettVarsel(
             varselId = nyOppgave.oppgaveReferanse.toString(),
             deltakerIdent = deltaker.deltakerIdent,
             tekster = oppgaveTypeDataDAO.minSideVarselTekster(),

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -48,6 +48,8 @@ topic:
     # topic.producer.min-side-varsel
     min-side-varsel:
       navn: min-side.aapen-brukervarsel-v1
+    min-side-mikrofrontend:
+      navn: min-side.aapen-microfrontend-v1
   # Bryter betegner av/på funksjon for kafkalytter. True (på), False (av).
   listener:
     # topic.listener.ung-soknad

--- a/app/src/main/resources/db/migration/V13__mikrofrontend.sql
+++ b/app/src/main/resources/db/migration/V13__mikrofrontend.sql
@@ -1,0 +1,11 @@
+CREATE TABLE mikrofrontend
+(
+    id               UUID PRIMARY KEY NOT NULL,
+    deltaker_id      UUID             NOT NULL, -- Referanse til deltaker
+    mikrofrontend_id VARCHAR(100)     NOT NULL,
+    status           VARCHAR(10)      NOT NULL,
+    opprettet        TIMESTAMP        NOT NULL,
+    endret           TIMESTAMP,
+
+    CONSTRAINT uk_mikrofrontend_deltaker_mf UNIQUE (deltaker_id, mikrofrontend_id)
+)

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/kafka/UngdomsytelseRapportertInntektKonsumentTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/kafka/UngdomsytelseRapportertInntektKonsumentTest.kt
@@ -15,7 +15,7 @@ import no.nav.ung.deltakelseopplyser.domene.inntekt.repository.RapportertInntekt
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.register.ungsak.OppgaveUngSakController
-import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
@@ -50,7 +50,7 @@ class UngdomsytelseRapportertInntektKonsumentTest : AbstractIntegrationTest() {
     lateinit var rapportertInntektRepository: RapportertInntektRepository
 
     @SpykBean
-    lateinit var mineSiderVarselService: MineSiderVarselService
+    lateinit var mineSiderService: MineSiderService
 
     @MockkBean
     lateinit var pdlService: PdlService
@@ -129,7 +129,7 @@ class UngdomsytelseRapportertInntektKonsumentTest : AbstractIntegrationTest() {
         await.atMost(10, TimeUnit.SECONDS).untilAsserted {
             verify(exactly = 1) { rapportertInntektHåndtererService.håndterRapportertInntekt(any()) }
             verify(exactly = 1) { deltakerService.hentDeltakterIder(any()) }
-            verify(exactly = 1) { mineSiderVarselService.deaktiverOppgave(any()) }
+            verify(exactly = 1) { mineSiderService.deaktiverOppgave(any()) }
             verify(exactly = 1) { rapportertInntektRepository.save(any()) }
 
             val oppgave = deltakerService.hentDeltakersOppgaver(søkerIdent).first()

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
@@ -17,15 +17,13 @@ import no.nav.k9.søknad.felles.type.Periode
 import no.nav.k9.søknad.felles.type.SøknadId
 import no.nav.pdl.generated.enums.IdentGruppe
 import no.nav.pdl.generated.hentident.IdentInformasjon
-import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
-import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import no.nav.ung.deltakelseopplyser.AbstractIntegrationTest
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerRepository
 import no.nav.ung.deltakelseopplyser.domene.oppgave.kafka.UngdomsytelseOppgavebekreftelse
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.register.ungsak.OppgaveUngSakController
-import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
@@ -40,18 +38,13 @@ import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterIn
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektYtelseDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.YtelseType
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
-import no.nav.ung.deltakelseopplyser.utils.TokenTestUtils.mockContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mockito.verifyNoMoreInteractions
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
@@ -76,7 +69,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
     lateinit var oppgaveUngSakController: OppgaveUngSakController
 
     @SpykBean
-    lateinit var mineSiderVarselService: MineSiderVarselService
+    lateinit var mineSiderService: MineSiderService
 
     @MockkBean
     lateinit var pdlService: PdlService
@@ -170,7 +163,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
         assertThat(oppgave.bekreftelse?.harGodtattEndringen).isFalse()
         assertThat(oppgave.bekreftelse?.uttalelseFraBruker).isEqualTo("Det er feil med datoene")
 
-        verify(exactly = 1) { mineSiderVarselService.deaktiverOppgave(oppgaveReferanse.toString()) }
+        verify(exactly = 1) { mineSiderService.deaktiverOppgave(oppgaveReferanse.toString()) }
     }
 
     @Test
@@ -211,7 +204,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
         assertThat(oppgave.bekreftelse?.harGodtattEndringen).isFalse()
         assertThat(oppgave.bekreftelse?.uttalelseFraBruker).isEqualTo("Det er feil inntekt i registeret")
 
-        verify(exactly = 1) { mineSiderVarselService.deaktiverOppgave(oppgaveReferanse.toString()) }
+        verify(exactly = 1) { mineSiderService.deaktiverOppgave(oppgaveReferanse.toString()) }
 
     }
 
@@ -250,7 +243,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
             )
         }
 
-        verify(exactly = 0) { mineSiderVarselService.deaktiverOppgave(oppgaveReferanse.toString()) }
+        verify(exactly = 0) { mineSiderService.deaktiverOppgave(oppgaveReferanse.toString()) }
     }
 
     private fun endreProgramperiode(

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -9,10 +9,8 @@ import no.nav.pdl.generated.hentident.IdentInformasjon
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerRepository
-import no.nav.ung.deltakelseopplyser.config.DeltakerappConfig
-import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService
-import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngSakService
@@ -63,7 +61,7 @@ class UngdomsprogramregisterServiceTest {
     lateinit var entityManager: EntityManager
 
     @MockkBean
-    lateinit var mineSiderVarselService: MineSiderVarselService
+    lateinit var mineSiderService: MineSiderService
 
     @MockkBean(relaxed = true)
     lateinit var ungSakService: UngSakService
@@ -85,7 +83,7 @@ class UngdomsprogramregisterServiceTest {
         deltakelseRepository.deleteAll()
         deltakerRepository.deleteAll()
 
-        justRun { mineSiderVarselService.opprettVarsel(any(), any(), any(), any(), any(), any()) }
+        justRun { mineSiderService.opprettVarsel(any(), any(), any(), any(), any(), any()) }
         springTokenValidationContextHolder.mockContext()
     }
 

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
@@ -16,13 +16,17 @@ import no.nav.ung.deltakelseopplyser.config.DeltakerappConfig
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService
+import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendStatus
+import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MikrofrontendRepository
+import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MikrofrontendService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngSakService
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseOpplysningDTO
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.soknad.kafka.Ungdomsytelsesøknad
-import no.nav.ung.deltakelseopplyser.domene.varsler.MineSiderVarselService
+import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MikrofrontendId
+import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
@@ -50,7 +54,8 @@ import java.time.ZonedDateTime
     UngdomsytelsesøknadService::class,
     UngdomsprogramregisterService::class,
     RapportertInntektService::class,
-    DeltakerappConfig::class
+    DeltakerappConfig::class,
+    MikrofrontendService::class
 )
 class UngdomsytelsesøknadServiceTest {
 
@@ -64,7 +69,7 @@ class UngdomsytelsesøknadServiceTest {
     lateinit var kontoregisterService: KontoregisterService
 
     @MockkBean
-    lateinit var mineSiderVarselService: MineSiderVarselService
+    lateinit var mineSiderService: MineSiderService
 
     @Autowired
     lateinit var ungdomsprogramDeltakelseRepository: UngdomsprogramDeltakelseRepository
@@ -75,10 +80,15 @@ class UngdomsytelsesøknadServiceTest {
     @Autowired
     lateinit var ungdomsytelsesøknadService: UngdomsytelsesøknadService
 
+    @Autowired
+    lateinit var mikrofrontendRepository: MikrofrontendRepository
+
     @BeforeAll
     fun setUp() {
         ungdomsprogramDeltakelseRepository.deleteAll()
-        justRun { mineSiderVarselService.opprettVarsel(any(), any(), any(), any(), any(), any()) }
+        mikrofrontendRepository.deleteAll()
+        justRun { mineSiderService.opprettVarsel(any(), any(), any(), any(), any(), any()) }
+        justRun { mineSiderService.aktiverMikrofrontend(any(), any(), any()) }
     }
 
     @Test
@@ -102,6 +112,15 @@ class UngdomsytelsesøknadServiceTest {
         assertThat(deltakelse.get().søktTidspunkt)
             .withFailMessage("Forventet at deltakelse med id %s var markert som søkt", deltakelseOpplysningDTO.id)
             .isNotNull()
+
+        assertThat(mikrofrontendRepository.findAll())
+            .withFailMessage("Forventet at mikrofrontend ble aktivert for deltakelse med id %s", deltakelseOpplysningDTO.id)
+            .isNotEmpty
+            .hasSize(1)
+            .first()
+            .matches { it.deltaker.deltakerIdent == søkerIdent }
+            .matches { it.mikrofrontendId == MikrofrontendId.UNGDOMSPROGRAMYTELSE_INNSYN.id }
+            .matches { it.status == MicrofrontendStatus.ENABLE}
     }
 
     private fun lagUngdomsytelseSøknad(


### PR DESCRIPTION
### **Behov / Bakgrunn**
Når veileder melder deltaker inn, og deltaker sender inn søknad om å få være med i programmet, skal det opprettes en inngang til deltakerportalen fra mine-sider (nav.no).

### **Løsning**
- Legger til service for å kunne aktivere en [predefinert mikrofrontend](https://github.com/navikt/ungdomsprogramytelse-innsyn-mikrofrontend) for deltaker.
- Mikrofrontenden lagres ned i databasen, slik at man har en referanse til den når man skal deaktivere den senere.

### **Andre endringer**
- Renamer pakke fra `varsler` til `minside`.
- Renamer klasse fra `MineSiderVarselService` til `MineSiderService`.

### **Skjermbilder** (hvis relevant)
![image](https://github.com/user-attachments/assets/79403861-d647-42e2-a9eb-1e4a64d463d7)

