### PR TITLE
Fikser Jackson combination not supported.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -13,7 +13,6 @@ import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.ArbeidOgFrilansRegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.BekreftelseDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretProgramperiodeDataDTO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeData
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
@@ -122,12 +121,9 @@ class OppgaveDAO(
             )
 
             is InntektsrapporteringOppgavetypeDataDAO -> {
-                val base = InntektsrapporteringOppgavetypeData(
-                    fraOgMed = this.fomDato,
-                    tilOgMed = this.tomDato
-                )
                 InntektsrapporteringOppgavetypeDataDTO(
-                    base = base,
+                    fraOgMed = this.fomDato,
+                    tilOgMed = this.tomDato,
                     rapportertInntekt = null
                 )
             }

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
@@ -30,13 +30,9 @@ data class RegisterinntektDTO(
     @JsonProperty("totalInntekt") val totalInntekt: Int = totalInntektArbeidOgFrilans + totalInntektYtelse,
 )
 
-data class InntektsrapporteringOppgavetypeData(
+data class InntektsrapporteringOppgavetypeDataDTO(
     @JsonProperty("fraOgMed") val fraOgMed: LocalDate,
     @JsonProperty("tilOgMed") val tilOgMed: LocalDate,
-)
-
-data class InntektsrapporteringOppgavetypeDataDTO(
-    @JsonUnwrapped val base: InntektsrapporteringOppgavetypeData,
     @JsonProperty("rapportertInntekt") val rapportertInntekt: RapportertInntektPeriodeinfoDTO? = null,
 ) : OppgavetypeDataDTO
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved deserialisering av `InntektsrapporteringOppgavetypeDataDTO` får man følgende feil:
`Cannot define Creator property "base" as @JsonUnwrapped: combination not yet supported
… through reference chain: … OppgaveDTO["oppgavetypeData"]`

Noe som betyr at Jackson pr. idag ikke støtter at man pakker ut (`@JsonUnwrapped`) et sub-objekt fra selve konstruktørargumentet i en `data class`.

Siden `InntektsrapporteringOppgavetypeDataDTO` kun har primærkonstruktør (ingen no-arg-constructor), klarer ikke Jackson å bygge objektet.

### **Løsning**
Fjerner `@JsonUnwrapped` og flater ut feltene manuelt.