### PR TITLE
Justerer OppgaveDAO id til å være i sync med primærnøkkel i databasen

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -17,7 +17,6 @@ class OppgaveDAO(
     @Column(name = "id", nullable = false)
     val id: UUID,
 
-    @Id
     @Column(name = "oppgave_referanse", nullable = false)
     val oppgaveReferanse: UUID,
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Får warnings ved oppstart:

WARN  org.hibernate.mapping.RootClass - HHH000038: Composite-id class does not override equals(): no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
WARN  org.hibernate.mapping.RootClass - HHH000039: Composite-id class does not override hashCode(): no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO


### **Løsning**

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
