### PR TITLE
Fikser historikkinnslag

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkEndringUtleder.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkEndringUtleder.kt
@@ -5,7 +5,6 @@ import no.nav.ung.deltakelseopplyser.kontrakt.register.historikk.Endringstype
 import java.util.*
 
 object DeltakelseHistorikkEndringUtleder {
-    private val logger = org.slf4j.LoggerFactory.getLogger(DeltakelseHistorikkEndringUtleder::class.java)
 
     fun utledEndring(
         nåværendeDeltakelseRevisjon: DeltakelseDAO,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkService.kt
@@ -24,7 +24,8 @@ class DeltakelseHistorikkService(
         logger.info("Henter historikk for deltakelse med id $id")
 
         val alleRevisjoner: List<Revision<Long, DeltakelseDAO>> =
-            deltakelseHistorikkRepository.findRevisions(id).toList()
+            deltakelseHistorikkRepository.findRevisions(id)
+                .toList()
                 .sortedBy { it.requiredRevisionInstant }
 
         if (alleRevisjoner.isEmpty()) {
@@ -32,37 +33,36 @@ class DeltakelseHistorikkService(
         }
 
         // Mapper over listen med indekser, slik at vi enkelt kan hente "forrige" revisjon
-        return alleRevisjoner
-            .mapIndexed { index, revision ->
-            val metadata = revision.metadata
+        return alleRevisjoner.mapIndexed { index, revision ->
+                val metadata = revision.metadata
 
-            val nåværendeRevisjon = revision.entity
+                val nåværendeRevisjon = revision.entity
 
-            // Henter forrige revisjon hvis den finnes
-            val forrigeRevisjon: DeltakelseDAO? =
-                alleRevisjoner.getOrNull(index - 1)?.entity
+                // Henter forrige revisjon hvis den finnes
+                val forrigeRevisjon: DeltakelseDAO? =
+                    alleRevisjoner.getOrNull(index - 1)?.entity
 
-            val historikkEndring = DeltakelseHistorikkEndringUtleder.utledEndring(
-                forrigeDeltakelseRevisjon = forrigeRevisjon,
-                nåværendeDeltakelseRevisjon = nåværendeRevisjon
-            )
+                val historikkEndring = DeltakelseHistorikkEndringUtleder.utledEndring(
+                    forrigeDeltakelseRevisjon = forrigeRevisjon,
+                    nåværendeDeltakelseRevisjon = nåværendeRevisjon
+                )
 
-            DeltakelseHistorikk(
-                revisjonstype = metadata.revisionType.somHistorikkType(),
-                endringstype = historikkEndring.endringstype,
-                revisjonsnummer = metadata.revisionNumber.get(),
-                deltakelse = nåværendeRevisjon,
-                opprettetAv = nåværendeRevisjon.opprettetAv!!,
-                opprettetTidspunkt = nåværendeRevisjon.opprettetTidspunkt.atZone(ZoneOffset.UTC),
-                endretAv = nåværendeRevisjon.endretAv,
-                endretTidspunkt = nåværendeRevisjon.endretTidspunkt!!.atZone(ZoneOffset.UTC),
-                endretStartdato = historikkEndring.endretStartdatoDataDTO,
-                endretSluttdato = historikkEndring.endretSluttdatoDataDTO,
-                søktTidspunktSatt = historikkEndring.søktTidspunktSatt
-            )
-        }.also {
-            logger.info("Fant ${it.size} historikkoppføringer for deltakelse med id $id")
-        }
+                DeltakelseHistorikk(
+                    revisjonstype = metadata.revisionType.somHistorikkType(),
+                    endringstype = historikkEndring.endringstype,
+                    revisjonsnummer = metadata.revisionNumber.get(),
+                    deltakelse = nåværendeRevisjon,
+                    opprettetAv = nåværendeRevisjon.opprettetAv!!,
+                    opprettetTidspunkt = nåværendeRevisjon.opprettetTidspunkt.atZone(ZoneOffset.UTC),
+                    endretAv = nåværendeRevisjon.endretAv,
+                    endretTidspunkt = nåværendeRevisjon.endretTidspunkt!!.atZone(ZoneOffset.UTC),
+                    endretStartdato = historikkEndring.endretStartdatoDataDTO,
+                    endretSluttdato = historikkEndring.endretSluttdatoDataDTO,
+                    søktTidspunktSatt = historikkEndring.søktTidspunktSatt
+                )
+            }.also {
+                logger.info("Fant ${it.size} historikkoppføringer for deltakelse med id $id")
+            }
     }
 
     private fun RevisionMetadata.RevisionType.somHistorikkType() = when (this) {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkService.kt
@@ -25,6 +25,7 @@ class DeltakelseHistorikkService(
 
         val alleRevisjoner: List<Revision<Long, DeltakelseDAO>> =
             deltakelseHistorikkRepository.findRevisions(id).toList()
+                .sortedBy { it.requiredRevisionInstant }
 
         if (alleRevisjoner.isEmpty()) {
             return emptyList()
@@ -32,7 +33,6 @@ class DeltakelseHistorikkService(
 
         // Mapper over listen med indekser, slik at vi enkelt kan hente "forrige" revisjon
         return alleRevisjoner
-            .sortedBy { it.requiredRevisionInstant }
             .mapIndexed { index, revision ->
             val metadata = revision.metadata
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkService.kt
@@ -31,7 +31,9 @@ class DeltakelseHistorikkService(
         }
 
         // Mapper over listen med indekser, slik at vi enkelt kan hente "forrige" revisjon
-        return alleRevisjoner.mapIndexed { index, revision ->
+        return alleRevisjoner
+            .sortedBy { it.requiredRevisionInstant }
+            .mapIndexed { index, revision ->
             val metadata = revision.metadata
 
             val nåværendeRevisjon = revision.entity


### PR DESCRIPTION
### **Behov / Bakgrunn**
Da vi hentet historikk via `findRevisions(id)`, brukte vi rev‐listen direkte for å slå opp “forrige” revisjon basert på indeks. Men `Envers` gir rev‐ID‐er fra en global sekvens (`revinfo_seq`) med store hopp (f.eks. 1905 → 2002 → 1906). Siden sekvensen brukes av alle auditerte entiteter, var numerisk rekkefølge på rev‐ID‐ene ikke nødvendigvis lik kronologisk rekkefølge. Resultatet ble at “forrige” revisjon pekte feil når vi hentet den fra den usorterte alleRevisjoner‐listen.

### **Løsning**
Sortere alle revisjonene på `requiredRevisionInstant` som er tidspunktet for historikkinnslaget, noe som løser endringer kronologisk og ikke er avhengig av revisjonsnummeret.
