### PR TITLE
Utleder deltakelseId fra søknad.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,7 +23,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <ung-sak.version>1.6.0</ung-sak.version>
         <fp-sak.version>2.7.3</fp-sak.version>
-        <k9-format.version>12.2.2</k9-format.version>
+        <k9-format.version>12.3.0</k9-format.version>
         <k9-felles.version>4.6.5</k9-felles.version>
         <graphql-kotlin.version>8.8.0</graphql-kotlin.version>
         <tms-kotlin-builder.version>2.1.1</tms-kotlin-builder.version>

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramDeltakelseRepository.kt
@@ -10,18 +10,4 @@ interface UngdomsprogramDeltakelseRepository : JpaRepository<DeltakelseDAO, UUID
     fun findByDeltaker_IdIn(deltakerIds: List<UUID>): List<DeltakelseDAO>
 
     fun findByIdAndDeltaker_IdIn(id: UUID, deltakerIds: List<UUID>): DeltakelseDAO?
-
-    @Query(
-        value = """
-        SELECT * FROM ungdomsprogram_deltakelse
-        WHERE deltaker_id IN (:deltakterIder)
-          AND lower(periode) = :periodeStartdato
-        LIMIT 1
-    """,
-        nativeQuery = true
-    )
-    fun finnDeltakelseSomStarter(
-        @Param("deltakterIder") deltakterIder: List<UUID>,
-        @Param("periodeStartdato") periodeStartdato: LocalDate
-    ): DeltakelseDAO?
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadService.kt
@@ -56,23 +56,19 @@ class UngdomsytelsesøknadService(
             oppgaveReferanse = sendSøknadOppgave.oppgaveReferanse
         )
 
-        // TODO: Fjern denne når vi har fått inn søknader med deltakelseId i Q.
-        // Dette er en midlertidig løsning for å håndtere søknader som ikke har deltakelseId satt.
-        kotlin.runCatching {
-            logger.info("Henter deltakelse med id $deltakelseId")
-            val deltakelseDAO = deltakelseRepository.findByIdAndDeltaker_IdIn(deltakelseId, deltakterIder)
-                ?: throw IllegalStateException("Fant ingen deltakelse med id=$deltakelseId for deltaker med id=$deltakterIder")
+        logger.info("Henter deltakelse med id $deltakelseId")
+        val deltakelseDAO = deltakelseRepository.findByIdAndDeltaker_IdIn(deltakelseId, deltakterIder)
+            ?: throw IllegalStateException("Fant ingen deltakelse med id=$deltakelseId for deltaker med id=$deltakterIder")
 
-            if (deltakelseDAO.søktTidspunkt == null) {
-                logger.info("Markerer deltakelse med id={} som søkt for.", deltakelseDAO.id)
-                deltakelseDAO.markerSomHarSøkt()
-                deltakelseRepository.save(deltakelseDAO)
-            } else {
-                logger.info(
-                    "Deltakelse med id={} er allerede markert som søkt. Vurderer å løse oppgaver.",
-                    deltakelseDAO.id
-                )
-            }
+        if (deltakelseDAO.søktTidspunkt == null) {
+            logger.info("Markerer deltakelse med id={} som søkt for.", deltakelseDAO.id)
+            deltakelseDAO.markerSomHarSøkt()
+            deltakelseRepository.save(deltakelseDAO)
+        } else {
+            logger.info(
+                "Deltakelse med id={} er allerede markert som søkt. Vurderer å løse oppgaver.",
+                deltakelseDAO.id
+            )
         }
 
         logger.info("Lagrer søknad med journalpostId: {}", ungdomsytelsesøknad.journalpostId)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadService.kt
@@ -3,7 +3,6 @@ package no.nav.ung.deltakelseopplyser.domene.soknad
 import no.nav.k9.søknad.JsonUtils
 import no.nav.k9.søknad.ytelse.ung.v1.Ungdomsytelse
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
-import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendService
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendStatus
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MinSideMicrofrontendStatusDAO
@@ -36,9 +35,9 @@ class UngdomsytelsesøknadService(
         logger.info("Håndterer mottatt søknad.")
         val søknad = ungdomsytelsesøknad.søknad
         val oppgaveReferanse = UUID.fromString(søknad.søknadId.id)
-        val ungdomsytelse = søknad.getYtelse<Ungdomsytelse>()
-        val søktFraDato = ungdomsytelse.søknadsperiode.fraOgMed
         val deltakerIdent = søknad.søker.personIdent.verdi
+        val ungdomsytelse = søknad.getYtelse<Ungdomsytelse>()
+        val deltakelseId = ungdomsytelse.deltakelseId
 
         val deltakterIder = deltakerService.hentDeltakterIder(deltakerIdent)
         if (deltakterIder.isEmpty()) {
@@ -49,10 +48,6 @@ class UngdomsytelsesøknadService(
             .find { it.oppgaveReferanse == oppgaveReferanse && it.oppgavetype == Oppgavetype.SØK_YTELSE }
             ?: throw IllegalStateException("Fant ingen deltakere med ident oppgitt i søknaden som har oppgave for oppgaveReferanse=$oppgaveReferanse")
 
-        logger.info("Henter deltakelse som starter $søktFraDato")
-        val deltakelseDAO = deltakelseRepository.finnDeltakelseSomStarter(deltakterIder, søktFraDato)
-            ?: throw IllegalStateException("Fant ingen deltakelse som starter $søktFraDato for deltaker med id=$deltakterIder")
-
         val deltaker = deltakerService.finnDeltakerGittIdent(deltakerIdent)
             ?: throw IllegalStateException("Fant ingen deltakere med ident oppgitt i søknaden")
 
@@ -61,30 +56,38 @@ class UngdomsytelsesøknadService(
             oppgaveReferanse = sendSøknadOppgave.oppgaveReferanse
         )
 
-        if (deltakelseDAO.søktTidspunkt == null) {
-            logger.info("Markerer deltakelse med id={} som søkt for.", deltakelseDAO.id)
-            deltakelseDAO.markerSomHarSøkt()
-            deltakelseRepository.save(deltakelseDAO)
-        } else {
-            logger.info(
-                "Deltakelse med id={} er allerede markert som søkt. Vurderer å løse oppgaver.",
-                deltakelseDAO.id
-            )
+        // TODO: Fjern denne når vi har fått inn søknader med deltakelseId i Q.
+        // Dette er en midlertidig løsning for å håndtere søknader som ikke har deltakelseId satt.
+        kotlin.runCatching {
+            logger.info("Henter deltakelse med id $deltakelseId")
+            val deltakelseDAO = deltakelseRepository.findByIdAndDeltaker_IdIn(deltakelseId, deltakterIder)
+                ?: throw IllegalStateException("Fant ingen deltakelse med id=$deltakelseId for deltaker med id=$deltakterIder")
+
+            if (deltakelseDAO.søktTidspunkt == null) {
+                logger.info("Markerer deltakelse med id={} som søkt for.", deltakelseDAO.id)
+                deltakelseDAO.markerSomHarSøkt()
+                deltakelseRepository.save(deltakelseDAO)
+            } else {
+                logger.info(
+                    "Deltakelse med id={} er allerede markert som søkt. Vurderer å løse oppgaver.",
+                    deltakelseDAO.id
+                )
+            }
         }
 
         logger.info("Lagrer søknad med journalpostId: {}", ungdomsytelsesøknad.journalpostId)
         søknadRepository.save(ungdomsytelsesøknad.somUngSøknadDAO())
 
-        logger.info("Aktiverer mikrofrontend for deltaker med deltakelseId: {}", deltakelseDAO.id)
+        logger.info("Aktiverer mikrofrontend for deltaker med id: {}", deltaker.id)
         microfrontendService.sendOgLagre(
             MinSideMicrofrontendStatusDAO(
                 id = UUID.randomUUID(),
-                deltaker = deltakelseDAO.deltaker,
+                deltaker = deltaker,
                 status = MicrofrontendStatus.ENABLE,
                 opprettet = ZonedDateTime.now(ZoneOffset.UTC),
             )
         ).also {
-            logger.info("Mikrofrontend aktivert for deltaker med deltakelseId: {}", deltakelseDAO.id)
+            logger.info("Mikrofrontend aktivert for deltaker med id: {}", deltaker.id)
         }
     }
 

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
@@ -95,58 +95,6 @@ class UngdomsprogramregisterRepositoryTest {
         }
     }
 
-    @Test
-    fun `Forventer å finne deltakelse som starter på eksakt dato`() {
-        val deltaker = DeltakerDAO(
-            id = UUID.randomUUID(),
-            deltakerIdent = "123",
-            deltakelseList = mutableListOf(),
-        )
-        entityManager.persist(deltaker)
-        val deltakerIdenter = listOf(deltaker.id)
-
-        val førsteDeltakelseStartdato = LocalDate.of(2025, 1, 1)
-        val førsteDeltakelse = DeltakelseDAO(
-            deltaker = deltaker,
-            periode = Range.closed(førsteDeltakelseStartdato, førsteDeltakelseStartdato.plusWeeks(1))
-        )
-        entityManager.persist(førsteDeltakelse)
-
-        val andreDeltakelseStartdato = førsteDeltakelseStartdato.plusWeeks(1).plusDays(1)
-        val andreDeltakelse = DeltakelseDAO(
-            deltaker = deltaker,
-            periode = Range.closedInfinite(andreDeltakelseStartdato)
-        )
-        entityManager.persist(andreDeltakelse)
-
-        entityManager.flush()
-
-        val førsteDeltakelseResultat = repository.finnDeltakelseSomStarter(deltakerIdenter, førsteDeltakelseStartdato)
-        assertThat(førsteDeltakelseResultat)
-            .withFailMessage("Forventet å finne deltakelse som starter på %s, men fikk null", førsteDeltakelseStartdato)
-            .isNotNull
-        assertThat(førsteDeltakelseResultat!!.getFom())
-            .withFailMessage("Forventet at deltakelse skulle starte %s", førsteDeltakelseStartdato)
-            .isEqualTo(førsteDeltakelseStartdato)
-
-        val andreDeltakelseResultat = repository.finnDeltakelseSomStarter(deltakerIdenter, andreDeltakelseStartdato)
-        assertThat(andreDeltakelseResultat)
-            .withFailMessage("Forventet å finne deltakelse som starter %s, men fikk null", andreDeltakelseStartdato)
-            .isNotNull
-        assertThat(andreDeltakelseResultat!!.getFom())
-            .withFailMessage("Forventet at deltakelse skulle starte %s", andreDeltakelseStartdato)
-            .isEqualTo(andreDeltakelseStartdato)
-
-        val ikkeEksisterendeStartdato = LocalDate.of(2025, 1, 1).minusDays(1)
-        val ikkeEksisterendeDeltakelseResultat = repository.finnDeltakelseSomStarter(
-            deltakerIdenter,
-            ikkeEksisterendeStartdato
-        )
-        assertThat(ikkeEksisterendeDeltakelseResultat)
-            .withFailMessage("Forventet å ikke finne deltakelse som starter %s", ikkeEksisterendeStartdato)
-            .isNull()
-    }
-
     companion object {
         @JvmStatic
         fun perioderTilTest(): Stream<Arguments> {

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelseOppgavebekreftelseKonsumentTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelseOppgavebekreftelseKonsumentTest.kt
@@ -80,6 +80,7 @@ class UngdomsytelseOppgavebekreftelseKonsumentTest : AbstractIntegrationTest() {
                     "ytelse": {
                       "type": "UNGDOMSYTELSE",
                       "søknadType": "DELTAKELSE_SØKNAD",
+                      "deltakelseId": "${deltakelse.id}",
                       "søktFraDatoer": ["$deltakelseStart"],
                       "inntekter": null
                     },
@@ -104,7 +105,7 @@ class UngdomsytelseOppgavebekreftelseKonsumentTest : AbstractIntegrationTest() {
         await.atMost(10, TimeUnit.SECONDS).untilAsserted {
             verify(exactly = 1) { ungdomsytelsesøknadService.håndterMottattSøknad(any()) }
             verify(exactly = 1) { deltakerService.hentDeltakterIder(any()) }
-            verify(exactly = 1) { ungdomsprogramDeltakelseRepository.finnDeltakelseSomStarter(any(), any()) }
+            verify(exactly = 1) { ungdomsprogramDeltakelseRepository.findByIdAndDeltaker_IdIn(any(), any()) }
             verify(exactly = 1) { søknadRepository.save(any()) }
         }
     }

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
@@ -42,6 +42,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.LocalDate
 import java.time.ZonedDateTime
+import java.util.*
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -107,6 +108,7 @@ class UngdomsytelsesøknadServiceTest {
         ungdomsytelsesøknadService.håndterMottattSøknad(
             ungdomsytelsesøknad = lagUngdomsytelseSøknad(
                 søknadId = sendSøknadOppgave.oppgaveReferanse.toString(),
+                deltakelseId = deltakelseOpplysningDTO.id!!,
                 søkerIdent = søkerIdent,
                 deltakelseStart = deltakelseStart
             )
@@ -135,6 +137,7 @@ class UngdomsytelsesøknadServiceTest {
 
     private fun lagUngdomsytelseSøknad(
         søknadId: String,
+        deltakelseId: UUID,
         søkerIdent: String,
         deltakelseStart: String,
     ) = Ungdomsytelsesøknad(
@@ -149,6 +152,7 @@ class UngdomsytelsesøknadServiceTest {
                 Ungdomsytelse()
                     .medSøknadType(UngSøknadstype.DELTAKELSE_SØKNAD)
                     .medStartdato(LocalDate.parse(deltakelseStart))
+                    .medDeltakelseId(deltakelseId)
             )
     )
 

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/kafka/UngdomsytelsesøknadKonsumentTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/kafka/UngdomsytelsesøknadKonsumentTest.kt
@@ -56,7 +56,7 @@ class UngdomsytelsesøknadKonsumentTest : AbstractIntegrationTest() {
         every { deltakerService.hentDeltakterIder(any()) } returns listOf(UUID.randomUUID())
 
         // med eksisterende deltakelse...
-        every { deltakelseRepository.finnDeltakelseSomStarter(any(), any()) } returns DeltakelseDAO(
+        every { deltakelseRepository.findByIdAndDeltaker_IdIn(any(), any()) } returns DeltakelseDAO(
             id = UUID.randomUUID(),
             deltaker = DeltakerDAO(
                 deltakerIdent = søkerIdent,


### PR DESCRIPTION
### **Behov / Bakgrunn**
I registerappen utleder man deltakelse utifra startdato oppgitt i søknaden som samsvarer med startdato i deltakelsen.
Men hvis søknad på kø skulle feile, e.g. pga. feilende journalføring, og veileder endrer startdato, vil man ikke kunne utlede deltakelsen.

### **Løsning**
Henter deltakelseId fra søknaden slik at vi kan finne fram til riktig deltakelse i ung-deltakelse-opplyser.
