### PR TITLE
Henter diskresjonskoder på deltaker.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -28,6 +28,7 @@
         <graphql-kotlin.version>8.8.0</graphql-kotlin.version>
         <tms-kotlin-builder.version>2.1.1</tms-kotlin-builder.version>
         <tms-mikrofrontend-builder.version>3.0.0</tms-mikrofrontend-builder.version>
+        <sif-abac-kontrakt.version>1.4.1</sif-abac-kontrakt.version>
     </properties>
     <dependencies>
 
@@ -122,7 +123,7 @@
         <dependency>
             <groupId>no.nav.sif.abac</groupId>
             <artifactId>kontrakt</artifactId>
-            <version>1.4.0</version>
+            <version>${sif-abac-kontrakt.version}</version>
         </dependency>
         <!-- K9 Kontrakter -->
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
@@ -3,6 +3,7 @@ package no.nav.ung.deltakelseopplyser.domene.deltaker
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import no.nav.pdl.generated.hentperson.Navn
+import no.nav.sif.abac.kontrakt.abac.Diskresjonskode
 import java.time.LocalDate
 import java.util.*
 
@@ -11,6 +12,9 @@ data class DeltakerPersonalia(
     val deltakerIdent: String,
     val navn: Navn,
     val fødselsdato: LocalDate,
+
+    @Schema(description = "Diskresjonskoder som gjelder for deltakeren. Vl være tom hvis deltaker ikke har diskresjonskoder satt.")
+    val diskresjonskoder: Set<Diskresjonskode>,
 
     @Schema(hidden = true)
     private val programOppstartdato: LocalDate? = null,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/abac/SifAbacPdpService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/abac/SifAbacPdpService.kt
@@ -1,14 +1,20 @@
 package no.nav.ung.deltakelseopplyser.integration.abac
 
+import no.nav.sif.abac.kontrakt.abac.Diskresjonskode
 import no.nav.sif.abac.kontrakt.abac.dto.UngdomsprogramTilgangskontrollInputDto
+import no.nav.sif.abac.kontrakt.person.PersonIdent
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
 import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
+import org.springframework.web.ErrorResponseException
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestTemplate
@@ -26,12 +32,13 @@ import org.springframework.web.client.RestTemplate
     )
 class SifAbacPdpService(
     @Qualifier("sifAbacPdpKlient")
-    private val sifAbacPdpKlient: RestTemplate
+    private val sifAbacPdpKlient: RestTemplate,
 ) {
     private companion object {
         private val logger: Logger = LoggerFactory.getLogger(SifAbacPdpService::class.java)
 
         private val hendelseInnsendingUrl = "/ungdomsprogramveiledning"
+        private val diskresjonsKoderUrl = "/diskresjonskoder"
     }
 
     fun ansattHarTilgang(input: UngdomsprogramTilgangskontrollInputDto): Boolean {
@@ -43,6 +50,32 @@ class SifAbacPdpService(
             Decision::class.java
         )
         return response.body!! == Decision.Permit
+    }
+
+    fun hentDiskresjonskoder(personIdent: PersonIdent): Set<Diskresjonskode> {
+        return kotlin.runCatching {
+            sifAbacPdpKlient.exchange(
+                "$diskresjonsKoderUrl/person-fnr",
+                HttpMethod.POST,
+                HttpEntity(personIdent),
+                object : ParameterizedTypeReference<Set<Diskresjonskode>>() {}
+            )
+        }.fold(
+            onSuccess = { response ->
+                response.body ?: emptySet()
+            },
+            onFailure = { exception: Throwable ->
+                logger.error("Henting av diskresjonskoder fra sif-abac-pdp feilet", exception)
+                throw ErrorResponseException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    ProblemDetail.forStatusAndDetail(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        "Feil ved henting av diskresjonskoder"
+                    ),
+                    exception
+                )
+            }
+        )
     }
 
     enum class Decision {

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonliaTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonliaTest.kt
@@ -14,7 +14,8 @@ internal class DeltakerPersonaliaTest {
         deltakerIdent = FødselsnummerGenerator.neste(),
         navn = Navn("Ola", null, "Nordmann"),
         fødselsdato = fødselsdato,
-        programOppstartdato = programOppstartdato
+        programOppstartdato = programOppstartdato,
+        diskresjonskoder = emptySet()
     )
 
     @Test

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
@@ -23,6 +23,7 @@ import no.nav.ung.deltakelseopplyser.domene.oppgave.OppgaveService
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.soknad.kafka.Ungdomsytelsesøknad
+import no.nav.ung.deltakelseopplyser.integration.abac.SifAbacPdpService
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngSakService
@@ -59,9 +60,12 @@ import java.util.*
     RapportertInntektService::class,
     DeltakerappConfig::class,
     MicrofrontendService::class,
-    OppgaveService::class,
+    OppgaveService::class
 )
 class UngdomsytelsesøknadServiceTest {
+
+    @MockkBean
+    lateinit var sifAbacPdpService: SifAbacPdpService
 
     @MockkBean
     lateinit var pdlService: PdlService


### PR DESCRIPTION
### **Behov / Bakgrunn**
**Informasjonssikkerhet / K255.1 - Nav skal beskytte brukere med adressebeskyttelse**

Det er ikke hemmelig at en person har adressebeskyttelse.

Hvis en veileder får tilgang til en bruker med adressebeskyttelse, bør dette markeres tydelig i skjermbildet, for eksempel med uthevning, farge, ikon eller lignende. Dette gjør den ansatte ekstra oppmerksom på at opplysningene må behandles med spesiell varsomhet.

### **Løsning**
- Kaller sif-abac-pdp for å hente diskresjonskode på deltaker.
  Dersom kallet til sif-abac-pdp feiler, skal kallet for å hente deltaker personalia også feile. Vi ønsker ikke å returnere tom set her.

- Utvider `DeltakerPersonalia` med felt for `diskresjonskoder`.

### **Andre endringer**
- Bumper sif-abac-kontrakt.version.

### **Skjermbilder** (hvis relevant)
