### PR TITLE
TSFF-1664: Inverterer uttalelse i OppgaveBekreftelse.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,7 +23,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <ung-sak.version>3.0.1</ung-sak.version>
         <fp-sak.version>2.7.3</fp-sak.version>
-        <k9-format.version>12.3.0</k9-format.version>
+        <k9-format.version>12.3.1</k9-format.version>
         <k9-felles.version>4.6.8</k9-felles.version>
         <graphql-kotlin.version>8.8.0</graphql-kotlin.version>
         <tms-kotlin-builder.version>2.1.1</tms-kotlin-builder.version>

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
@@ -56,8 +56,8 @@ class OppgaveService(
 
         forsikreRiktigOppgaveBekreftelse(oppgave, oppgaveBekreftelse)
         val bekreftelse = oppgaveBekreftelse.getBekreftelse<Bekreftelse>()
-        oppgave.oppgaveBekreftelse = no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveBekreftelse(
-            harGodtattEndringen = bekreftelse.harBrukerGodtattEndringen(),
+        oppgave.oppgaveBekreftelse = OppgaveBekreftelse(
+            harUttalelse = bekreftelse.harUttalelse(),
             uttalelseFraBruker = bekreftelse.uttalelseFraBruker
         )
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveBekreftelse.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveBekreftelse.kt
@@ -1,6 +1,6 @@
 package no.nav.ung.deltakelseopplyser.domene.oppgave.repository
 
 class OppgaveBekreftelse(
-    val harGodtattEndringen: Boolean,
+    val harUttalelse: Boolean,
     val uttalelseFraBruker: String? = null,
 )

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -76,7 +76,7 @@ class OppgaveDAO(
         )
 
         fun OppgaveBekreftelse.tilDTO(): BekreftelseDTO = BekreftelseDTO(
-            harGodtattEndringen = harGodtattEndringen,
+            harUttalelse = harUttalelse,
             uttalelseFraBruker = uttalelseFraBruker,
         )
 

--- a/app/src/main/resources/db/migration/V15__oppgave_bekreftelse_invert_uttalelse.sql
+++ b/app/src/main/resources/db/migration/V15__oppgave_bekreftelse_invert_uttalelse.sql
@@ -1,0 +1,9 @@
+UPDATE oppgave
+SET oppgave_bekreftelse = jsonb_set(
+        oppgave_bekreftelse - 'harGodtattEndringen', -- Fjerner gammel felt
+        '{harUttalelse}', -- Setter nytt felt
+        to_jsonb(NOT (oppgave_bekreftelse ->> 'harGodtattEndringen')::boolean), -- Inverterer verdien
+        true -- Oppretter felt hvis det ikke finnes. Da harUttalelse ikke eksistert før, må dette settes til true.
+                          )
+WHERE oppgave_bekreftelse IS NOT NULL
+  AND oppgave_bekreftelse ? 'harGodtattEndringen'; -- Sjekker at feltet finnes

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/RapportertInntektServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/inntekt/RapportertInntektServiceTest.kt
@@ -78,7 +78,7 @@ class RapportertInntektServiceTest {
                     rapportertInntekt = null // Forventes oppdatert av tjenesten
                 ),
                 bekreftelse = BekreftelseDTO(
-                    harGodtattEndringen = true,
+                    harUttalelse = true,
                     uttalelseFraBruker = null
                 ),
                 status = OppgaveStatus.LØST,
@@ -113,7 +113,7 @@ class RapportertInntektServiceTest {
                 rapportertInntekt = null // Forventes oppdatert av tjenesten
             ),
             bekreftelse = BekreftelseDTO(
-                harGodtattEndringen = true,
+                harUttalelse = true,
                 uttalelseFraBruker = null
             ),
             status = OppgaveStatus.LØST,

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
@@ -147,7 +147,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
                 EndretStartdatoBekreftelse(
                     oppgaveReferanse,
                     LocalDate.now(),
-                    false
+                    true
                 ).medUttalelseFraBruker("Det er feil med datoen")
             )
         )
@@ -160,7 +160,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
         assertThat(oppgave.oppgaveReferanse).isEqualTo(oppgaveReferanse)
         assertThat(oppgave.oppgavetypeData).isInstanceOf(EndretStartdatoDataDTO::class.java)
         assertThat(oppgave.bekreftelse).isNotNull
-        assertThat(oppgave.bekreftelse?.harGodtattEndringen).isFalse()
+        assertThat(oppgave.bekreftelse?.harUttalelse).isTrue()
         assertThat(oppgave.bekreftelse?.uttalelseFraBruker).isEqualTo("Det er feil med datoen")
 
         verify(exactly = 1) { mineSiderService.deaktiverOppgave(oppgaveReferanse.toString()) }
@@ -199,7 +199,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
                 EndretSluttdatoBekreftelse(
                     oppgaveReferanse,
                     startdato.plusDays(3),
-                    false
+                    true
                 ).medUttalelseFraBruker("Det er feil med datoen")
             )
         )
@@ -213,7 +213,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
         assertThat(oppgave.oppgaveReferanse).isEqualTo(oppgaveReferanse)
         assertThat(oppgave.oppgavetypeData).isInstanceOf(EndretSluttdatoDataDTO::class.java)
         assertThat(oppgave.bekreftelse).isNotNull
-        assertThat(oppgave.bekreftelse?.harGodtattEndringen).isFalse()
+        assertThat(oppgave.bekreftelse?.harUttalelse).isTrue()
         assertThat(oppgave.bekreftelse?.uttalelseFraBruker).isEqualTo("Det er feil med datoen")
 
         verify(exactly = 1) { mineSiderService.deaktiverOppgave(oppgaveReferanse.toString()) }
@@ -243,7 +243,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
                 deltakerIdent,
                 InntektBekreftelse(
                     oppgaveReferanse,
-                    false,
+                    true,
                     "Det er feil inntekt i registeret"
                 )
             )
@@ -257,7 +257,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
         assertThat(oppgave.oppgaveReferanse).isEqualTo(oppgaveReferanse)
         assertThat(oppgave.oppgavetypeData).isInstanceOf(KontrollerRegisterinntektOppgavetypeDataDTO::class.java)
         assertThat(oppgave.bekreftelse).isNotNull
-        assertThat(oppgave.bekreftelse?.harGodtattEndringen).isFalse()
+        assertThat(oppgave.bekreftelse?.harUttalelse).isTrue()
         assertThat(oppgave.bekreftelse?.uttalelseFraBruker).isEqualTo("Det er feil inntekt i registeret")
 
         verify(exactly = 1) { mineSiderService.deaktiverOppgave(oppgaveReferanse.toString()) }
@@ -290,7 +290,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
                     deltakerIdent,
                     InntektBekreftelse(
                         oppgaveReferanse,
-                        false,
+                        true,
                         "Det er feil inntekt"
                     )
                 )

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/BekreftelseDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/BekreftelseDTO.kt
@@ -3,6 +3,6 @@ package no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles
 import com.fasterxml.jackson.annotation.JsonProperty
 
 class BekreftelseDTO(
-    @JsonProperty("harGodtattEndringen") val harGodtattEndringen: Boolean,
+    @JsonProperty("harUttalelse") val harUttalelse: Boolean,
     @JsonProperty("uttalelseFraBruker") val uttalelseFraBruker: String? = null,
 )


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi skal nå spørre om deltaker har en tilbakemelding/uttalelse om endringene hvor de kan uttale seg, ikke om de godtar endringen. Dette inverterer svarene.

### **Løsning**
- Renamer felt `harGodtattEndringen` til `harUttalelse`.
- Migrerer eksisterende oppgavebekreftelser som har dette feltet satt og inverterer dens verdi.

### **Andre endringer**
- Bumper k9-format.

### **Skjermbilder** (hvis relevant)
