### PR TITLE
Sikre umiddelbar flush etter save for å unngå dupliserte varsler ved dobbeltklikk.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -74,7 +74,7 @@ class UngdomsprogramregisterService(
             deltakerService.lagreDeltaker(deltakelseDTO)
         }
 
-        val ungdomsprogramDAO = deltakelseRepository.save(deltakelseDTO.mapToDAO(deltakerDAO))
+        val ungdomsprogramDAO = deltakelseRepository.saveAndFlush(deltakelseDTO.mapToDAO(deltakerDAO))
 
         oppgaveService.opprettOppgave(
             deltaker = deltakerDAO,


### PR DESCRIPTION
### **Behov / Bakgrunn**
Brukere som treffer `/deltaker/innmelding` endepunktet to ganger raskt etter hverandre (f.eks. ved dobbeltklikk) kunne ende opp med å publisere to `min-side`varsel-meldinger, selv om det andre databaseinnslaget ble rullet tilbake av vår eksklusjonsbegrensning. Dette skjer fordi Hibernate utsetter den faktiske `SQL INSERT` til transaksjons-commit, slik at `opprettOppgave()` (og den påfølgende `mineSiderService.opprettVarsel()`) kjører før lagringen feiler.

Logg fra hendelse: https://logs.adeo.no/s/nav-logs-legacy/app/r/s/AAHFc

### **Løsning**
Tvinger en umiddelbar flush av den nye UngdomsprogramDeltakelse-enheten før `opprettOppgave() `kalles. Da vil en eventuell `DataIntegrityViolationException` kastes (og kan håndteres) før vi oppretter eller publiserer et andre varsel.

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
