### PR TITLE
TSFF-1546: Integrerer mot enhetsregisteret for å hente navn på arbeidsgiver.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveMapperService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveMapperService.kt
@@ -95,11 +95,13 @@ class OppgaveMapperService(
             ArbeidOgFrilansRegisterInntektDTO(
                 it.inntekt,
                 it.arbeidsgiver,
-                hentArbeidsgiverNavn(it.arbeidsgiver)
+                if (it.arbeidsgiver.erOrganisasjonsnummer()) hentArbeidsgiverNavn(it.arbeidsgiver) else null
             )
         },
         ytelseInntekter = ytelseInntekter.map { YtelseRegisterInntektDTO(it.inntekt, it.ytelsetype) }
     )
+
+    private fun String.erOrganisasjonsnummer() = length == 9 && all { it.isDigit() }
 
     private fun hentArbeidsgiverNavn(organisasjonsnummer: String): String? {
         return kotlin.runCatching { enhetsregisterService.hentOrganisasjonsinfo(organisasjonsnummer) }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveMapperService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveMapperService.kt
@@ -1,0 +1,125 @@
+package no.nav.ung.deltakelseopplyser.domene.oppgave
+
+import no.nav.ung.deltakelseopplyser.domene.inntekt.RapportertInntektService
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.EndretSluttdatoOppgaveDataDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.EndretStartdatoOppgaveDataDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.InntektsrapporteringOppgavetypeDataDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.KontrollerRegisterInntektOppgaveTypeDataDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveBekreftelse
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgavetypeDataDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.RegisterinntektDAO
+import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.SøkYtelseOppgavetypeDataDAO
+import no.nav.ung.deltakelseopplyser.integration.enhetsregisteret.EnhetsregisterService
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.ArbeidOgFrilansRegisterInntektDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.BekreftelseDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretSluttdatoDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretStartdatoDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.InntektsrapporteringOppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.RegisterinntektDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.SøkYtelseOppgavetypeDataDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.YtelseRegisterInntektDTO
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class OppgaveMapperService(
+    private val enhetsregisterService: EnhetsregisterService,
+    private val rapportertInntektService: RapportertInntektService,
+) {
+    private companion object {
+        private val logger = LoggerFactory.getLogger(OppgaveMapperService::class.java)
+    }
+
+    fun mapOppgaveTilDTO(oppgaveDAO: OppgaveDAO): OppgaveDTO {
+        return OppgaveDTO(
+            oppgaveReferanse = oppgaveDAO.oppgaveReferanse,
+            oppgavetype = oppgaveDAO.oppgavetype,
+            oppgavetypeData = oppgaveDAO.oppgavetypeDataDAO.tilDTO(),
+            bekreftelse = oppgaveDAO.oppgaveBekreftelse?.tilDTO(),
+            status = oppgaveDAO.status,
+            opprettetDato = oppgaveDAO.opprettetDato,
+            løstDato = oppgaveDAO.løstDato,
+            åpnetDato = oppgaveDAO.åpnetDato,
+            lukketDato = oppgaveDAO.lukketDato,
+            frist = oppgaveDAO.frist
+        ).let { oppgaveDTO ->
+            if (oppgaveDAO.erLøstInntektsrapportering()) {
+                rapportertInntektService.leggPåRapportertInntekt(oppgaveDTO)
+            } else oppgaveDTO
+        }
+    }
+
+    fun OppgaveBekreftelse.tilDTO(): BekreftelseDTO = BekreftelseDTO(
+        harUttalelse = harUttalelse,
+        uttalelseFraBruker = uttalelseFraBruker,
+    )
+
+    fun OppgavetypeDataDAO.tilDTO(): OppgavetypeDataDTO = when (this) {
+        is EndretStartdatoOppgaveDataDAO -> EndretStartdatoDataDTO(
+            nyStartdato = this.nyStartdato,
+            forrigeStartdato = this.forrigeStartdato,
+        )
+
+        is EndretSluttdatoOppgaveDataDAO -> EndretSluttdatoDataDTO(
+            nySluttdato = this.nySluttdato,
+            forrigeSluttdato = this.forrigeSluttdato,
+        )
+
+        is KontrollerRegisterInntektOppgaveTypeDataDAO -> KontrollerRegisterinntektOppgavetypeDataDTO(
+            fomDato,
+            tomDato,
+            registerinntekt.tilDTO()
+        )
+
+        is InntektsrapporteringOppgavetypeDataDAO -> {
+            InntektsrapporteringOppgavetypeDataDTO(
+                fraOgMed = this.fomDato,
+                tilOgMed = this.tomDato,
+                rapportertInntekt = null
+            )
+        }
+
+        is SøkYtelseOppgavetypeDataDAO -> SøkYtelseOppgavetypeDataDTO(
+            fomDato = fomDato
+        )
+    }
+
+    fun RegisterinntektDAO.tilDTO() = RegisterinntektDTO(
+        arbeidOgFrilansInntekter = arbeidOgFrilansInntekter.map {
+            ArbeidOgFrilansRegisterInntektDTO(
+                it.inntekt,
+                it.arbeidsgiver,
+                hentArbeidsgiverNavn(it.arbeidsgiver)
+            )
+        },
+        ytelseInntekter = ytelseInntekter.map { YtelseRegisterInntektDTO(it.inntekt, it.ytelsetype) }
+    )
+
+    private fun hentArbeidsgiverNavn(organisasjonsnummer: String): String? {
+        return kotlin.runCatching { enhetsregisterService.hentOrganisasjonsinfo(organisasjonsnummer) }
+            .fold(
+                onSuccess = {
+                    val sammensattnavn = it.navn?.sammensattnavn
+                    if (sammensattnavn.isNullOrBlank()) {
+                        logger.warn("Organisasjonsnummer $organisasjonsnummer hadde ikke navn i Enhetsregisteret. Returnerer null.")
+                        null
+                    } else
+                        sammensattnavn
+                },
+                onFailure = {
+                    logger.warn("Kunne ikke hente organisasjonsnavn for $organisasjonsnummer. Returnerer null. ${it.message}.")
+                    null
+                }
+            )
+    }
+
+    private fun OppgaveDAO.erLøstInntektsrapportering() =
+        this.oppgavetype == Oppgavetype.RAPPORTER_INNTEKT && this.status == OppgaveStatus.LØST
+
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveService.kt
@@ -12,7 +12,6 @@ import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.domene.oppgave.kafka.UngdomsytelseOppgavebekreftelse
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.*
-import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO.Companion.tilDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
@@ -32,6 +31,7 @@ class OppgaveService(
     private val deltakerService: DeltakerService,
     private val mineSiderService: MineSiderService,
     private val deltakerappConfig: DeltakerappConfig,
+    private val oppgaveMapperService: OppgaveMapperService
 ) {
     private companion object {
         private val logger = LoggerFactory.getLogger(OppgaveService::class.java)
@@ -108,7 +108,7 @@ class OppgaveService(
             aktivFremTil = frist,
         )
 
-        return nyOppgave.tilDTO()
+        return oppgaveMapperService.mapOppgaveTilDTO(nyOppgave)
     }
 
     private fun utledVarselLink(nyOppgave: OppgaveDAO) =
@@ -124,7 +124,7 @@ class OppgaveService(
 
         if (oppgave.status == OppgaveStatus.LØST) {
             logger.error("Oppgave med oppgaveReferanse $oppgaveReferanse er løst og kan ikke avbrytes.")
-            return oppgave.tilDTO();
+            return oppgaveMapperService.mapOppgaveTilDTO(oppgave)
         }
 
         logger.info("Markerer oppgave med oppgaveReferanse $oppgaveReferanse som avbrutt")
@@ -136,7 +136,7 @@ class OppgaveService(
         logger.info("Deaktiverer oppgave med oppgaveReferanse $oppgaveReferanse på min side")
         mineSiderService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
 
-        return oppdatertOppgave.tilDTO()
+        return oppgaveMapperService.mapOppgaveTilDTO(oppdatertOppgave)
     }
 
     fun utløperOppgave(deltaker: DeltakerDAO, oppgaveReferanse: UUID): OppgaveDTO {
@@ -146,7 +146,7 @@ class OppgaveService(
 
         if (oppgave.status == OppgaveStatus.LØST) {
             logger.error("Oppgave med oppgaveReferanse $oppgaveReferanse er løst og kan ikke utløpes.")
-            return oppgave.tilDTO();
+            return oppgaveMapperService.mapOppgaveTilDTO(oppgave)
         }
 
         logger.info("Markerer oppgave med oppgaveReferanse $oppgaveReferanse som utløpt")
@@ -158,7 +158,7 @@ class OppgaveService(
         logger.info("Deaktiverer oppgave med oppgaveReferanse $oppgaveReferanse på min side")
         mineSiderService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
 
-        return oppdatertOppgave.tilDTO()
+        return oppgaveMapperService.mapOppgaveTilDTO(oppdatertOppgave)
     }
 
     fun løsOppgave(deltaker: DeltakerDAO, oppgaveReferanse: UUID?): OppgaveDTO {
@@ -175,7 +175,7 @@ class OppgaveService(
 
         logger.info("Deaktiverer oppgave med oppgaveReferanse=$oppgaveReferanse da den er løst")
         mineSiderService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
-        return oppdatertOppgave.tilDTO()
+        return oppgaveMapperService.mapOppgaveTilDTO(oppdatertOppgave)
     }
 
     fun løsOppgave(oppgaveReferanse: UUID): OppgaveDTO {
@@ -189,7 +189,7 @@ class OppgaveService(
 
         logger.info("Deaktiverer oppgave med oppgaveReferanse=$oppgaveReferanse da den er løst")
         mineSiderService.deaktiverOppgave(oppgave.oppgaveReferanse.toString())
-        return oppdatertOppgave.tilDTO()
+        return oppgaveMapperService.mapOppgaveTilDTO(oppdatertOppgave)
     }
 
     fun lukkOppgave(oppgaveReferanse: UUID): OppgaveDTO {
@@ -227,7 +227,7 @@ class OppgaveService(
         val oppdatertOppgave = oppgave.markerSomLukket()
         deltakerService.oppdaterDeltaker(deltaker)
         mineSiderService.deaktiverOppgave(oppgaveReferanse.toString())
-        return oppdatertOppgave.tilDTO()
+        return oppgaveMapperService.mapOppgaveTilDTO(oppdatertOppgave)
     }
 
     fun åpneOppgave(oppgaveReferanse: UUID): OppgaveDTO {
@@ -235,7 +235,7 @@ class OppgaveService(
 
         val oppdatertOppgave = oppgave.markerSomÅpnet()
         deltakerService.oppdaterDeltaker(deltaker)
-        return oppdatertOppgave.tilDTO()
+        return oppgaveMapperService.mapOppgaveTilDTO(oppdatertOppgave)
     }
 
     private fun forsikreRiktigOppgaveBekreftelse(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgaveDAO.kt
@@ -1,9 +1,17 @@
 package no.nav.ung.deltakelseopplyser.domene.oppgave.repository
 
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.*
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
+import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.annotations.Type
 import org.hibernate.type.SqlTypes
@@ -60,66 +68,6 @@ class OppgaveDAO(
     @Column(name = "lukket_dato")
     var lukketDato: ZonedDateTime? = null,
 ) {
-
-    companion object {
-        fun OppgaveDAO.tilDTO() = OppgaveDTO(
-            oppgaveReferanse = oppgaveReferanse,
-            oppgavetype = oppgavetype,
-            oppgavetypeData = oppgavetypeDataDAO.tilDTO(),
-            bekreftelse = oppgaveBekreftelse?.tilDTO(),
-            status = status,
-            opprettetDato = opprettetDato,
-            løstDato = løstDato,
-            åpnetDato = åpnetDato,
-            lukketDato = lukketDato,
-            frist = frist
-        )
-
-        fun OppgaveBekreftelse.tilDTO(): BekreftelseDTO = BekreftelseDTO(
-            harUttalelse = harUttalelse,
-            uttalelseFraBruker = uttalelseFraBruker,
-        )
-
-        fun OppgavetypeDataDAO.tilDTO(): OppgavetypeDataDTO = when (this) {
-            is EndretStartdatoOppgaveDataDAO -> EndretStartdatoDataDTO(
-                nyStartdato = this.nyStartdato,
-                forrigeStartdato = this.forrigeStartdato,
-            )
-
-            is EndretSluttdatoOppgaveDataDAO -> EndretSluttdatoDataDTO(
-                nySluttdato = this.nySluttdato,
-                forrigeSluttdato = this.forrigeSluttdato,
-            )
-
-            is KontrollerRegisterInntektOppgaveTypeDataDAO -> KontrollerRegisterinntektOppgavetypeDataDTO(
-                fomDato,
-                tomDato,
-                registerinntekt.tilDTO()
-            )
-
-            is InntektsrapporteringOppgavetypeDataDAO -> {
-                InntektsrapporteringOppgavetypeDataDTO(
-                    fraOgMed = this.fomDato,
-                    tilOgMed = this.tomDato,
-                    rapportertInntekt = null
-                )
-            }
-
-            is SøkYtelseOppgavetypeDataDAO -> SøkYtelseOppgavetypeDataDTO(
-                fomDato = fomDato
-            )
-        }
-
-        fun RegisterinntektDAO.tilDTO() = RegisterinntektDTO(
-            arbeidOgFrilansInntekter = arbeidOgFrilansInntekter.map {
-                ArbeidOgFrilansRegisterInntektDTO(
-                    it.inntekt,
-                    it.arbeidsgiver
-                )
-            },
-            ytelseInntekter = ytelseInntekter.map { YtelseRegisterInntektDTO(it.inntekt, it.ytelsetype) }
-        )
-    }
 
     override fun toString(): String {
         return "OppgaveDAO(id=$id, oppgavetype=$oppgavetype, status=$status, opprettetDato=$opprettetDato, losDato=$løstDato)"

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgavetypeDataDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/repository/OppgavetypeDataDAO.kt
@@ -124,19 +124,7 @@ data class SøkYtelseOppgavetypeDataDAO(
 data class RegisterinntektDAO(
     @JsonProperty("arbeidOgFrilansInntekter") val arbeidOgFrilansInntekter: List<ArbeidOgFrilansRegisterInntektDAO>,
     @JsonProperty("ytelseInntekter") val ytelseInntekter: List<YtelseRegisterInntektDAO>,
-) {
-    companion object {
-        fun RegisterinntektDAO.tilDTO() = RegisterinntektDTO(
-            arbeidOgFrilansInntekter = arbeidOgFrilansInntekter.map {
-                ArbeidOgFrilansRegisterInntektDTO(
-                    it.inntekt,
-                    it.arbeidsgiver
-                )
-            },
-            ytelseInntekter = ytelseInntekter.map { YtelseRegisterInntektDTO(it.inntekt, it.ytelsetype) }
-        )
-    }
-}
+)
 
 data class InntektsrapporteringOppgavetypeDataDAO(
     @JsonFormat(pattern = "yyyy-MM-dd")

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/EnhetsregisterKlientKonfig.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/EnhetsregisterKlientKonfig.kt
@@ -1,0 +1,40 @@
+package no.nav.ung.deltakelseopplyser.integration.enhetsregisteret
+
+import no.nav.ung.deltakelseopplyser.http.MDCValuesPropagatingClientHttpRequestInterceptor
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders.CONTENT_TYPE
+import org.springframework.http.MediaType
+import org.springframework.web.client.RestTemplate
+import java.time.Duration
+
+@Configuration
+class EnhetsregisterKlientKonfig(
+    @Value("\${no.nav.gateways.enhetsregister-base-url}") private val enhetsregisterBaseUrl: String,
+) {
+
+    private companion object {
+        val logger: Logger = LoggerFactory.getLogger(EnhetsregisterKlientKonfig::class.java)
+    }
+
+
+    @Bean(name = ["enhetsregisterKlient"])
+    fun restTemplate(
+        builder: RestTemplateBuilder,
+        mdcInterceptor: MDCValuesPropagatingClientHttpRequestInterceptor,
+    ): RestTemplate {
+        return builder
+            .connectTimeout(Duration.ofSeconds(20))
+            .readTimeout(Duration.ofSeconds(20))
+            .defaultHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .rootUri(enhetsregisterBaseUrl)
+            .defaultMessageConverters()
+            .interceptors(mdcInterceptor)
+            .build()
+    }
+}
+

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/EnhetsregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/EnhetsregisterService.kt
@@ -74,7 +74,7 @@ class EnhetsregisterService(
     @Recover
     open fun hentOrganisasjonsinfo(ex: HttpClientErrorException): OrganisasjonRespons {
         val feilmelding = parseFeilmelding(ex.responseBodyAsString)
-        logger.warn("Klientfeil ${ex.statusCode} mot $TJENESTE_NAVN: $feilmelding")
+        logger.warn("Klientfeil ${ex.statusCode} mot $TJENESTE_NAVN: $feilmelding", ex)
 
         throw EnhetsregisterException(feilmelding, HttpStatus.valueOf(ex.statusCode.value()))
     }
@@ -82,13 +82,13 @@ class EnhetsregisterService(
     @Recover
     open fun recoverServerError(ex: HttpServerErrorException): OrganisasjonRespons {
         val feilmelding = parseFeilmelding(ex.responseBodyAsString)
-        logger.error("Serverfeil ${ex.statusCode} mot $TJENESTE_NAVN: $feilmelding")
+        logger.error("Serverfeil ${ex.statusCode} mot $TJENESTE_NAVN: $feilmelding", ex)
         throw EnhetsregisterException("Annen feil: $feilmelding", HttpStatus.valueOf(ex.statusCode.value()))
     }
 
     @Recover
     open fun recoverResourceAccess(ex: ResourceAccessException): OrganisasjonRespons {
-        logger.error("Tilgangsfeil mot $TJENESTE_NAVN: ${ex.message}")
+        logger.error("Tilgangsfeil mot $TJENESTE_NAVN: ${ex.message}", ex)
         throw EnhetsregisterException(
             "Kunne ikke nå enhetsregisteret: ${ex.message}",
             HttpStatus.SERVICE_UNAVAILABLE

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/EnhetsregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/EnhetsregisterService.kt
@@ -1,0 +1,124 @@
+package no.nav.ung.deltakelseopplyser.integration.enhetsregisteret
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Recover
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Service
+import org.springframework.web.ErrorResponseException
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpServerErrorException
+import org.springframework.web.client.ResourceAccessException
+import org.springframework.web.client.RestTemplate
+import java.net.URI
+
+/**
+ * Service for å hente organisasjonsinfo fra enhetsregisteret (ereg).
+ *
+ * Se [EREG API V1](https://ereg-services.dev.intern.nav.no/swagger-ui/index.html) for mer informasjon.
+ */
+
+@Retryable(
+    noRetryFor = [
+        ResourceAccessException::class,
+        EnhetsregisterException::class
+    ],
+    backoff = Backoff(
+        delayExpression = "\${spring.rest.retry.initialDelay}",
+        multiplierExpression = "\${spring.rest.retry.multiplier}",
+        maxDelayExpression = "\${spring.rest.retry.maxDelay}"
+    ),
+    maxAttemptsExpression = "\${spring.rest.retry.maxAttempts}",
+)
+@Service
+class EnhetsregisterService(
+    @Qualifier("enhetsregisterKlient") private val enhetsregisterKlient: RestTemplate,
+    private val objectMapper: ObjectMapper,
+) {
+    private companion object {
+        private val logger: Logger = LoggerFactory.getLogger(EnhetsregisterService::class.java)
+
+        const val TJENESTE_NAVN = "enhetsregisteret"
+
+        private val hentOrganisasjonInfoUrl = "/v2/organisasjon"
+    }
+
+    fun hentOrganisasjonsinfo(organisasjonsnummer: String): OrganisasjonRespons {
+        return kotlin.runCatching {
+            enhetsregisterKlient.exchange(
+                "$hentOrganisasjonInfoUrl/$organisasjonsnummer",
+                HttpMethod.GET,
+                null,
+                OrganisasjonRespons::class.java
+            )
+        }.fold(
+            onSuccess = { it.body!! },
+            onFailure = {
+                if (it is HttpClientErrorException.NotFound) {
+                    throw EnhetsregisterException(
+                        "Fant ikke organisasjon med organisasjonsnummer: $organisasjonsnummer",
+                        HttpStatus.NOT_FOUND
+                    )
+                }
+                throw it
+            }
+        )
+    }
+
+    @Recover
+    open fun hentOrganisasjonsinfo(ex: HttpClientErrorException): OrganisasjonRespons {
+        val feilmelding = parseFeilmelding(ex.responseBodyAsString)
+        logger.warn("Klientfeil ${ex.statusCode} mot $TJENESTE_NAVN: $feilmelding")
+
+        throw EnhetsregisterException(feilmelding, HttpStatus.valueOf(ex.statusCode.value()))
+    }
+
+    @Recover
+    open fun recoverServerError(ex: HttpServerErrorException): OrganisasjonRespons {
+        val feilmelding = parseFeilmelding(ex.responseBodyAsString)
+        logger.error("Serverfeil ${ex.statusCode} mot $TJENESTE_NAVN: $feilmelding")
+        throw EnhetsregisterException("Annen feil: $feilmelding", HttpStatus.valueOf(ex.statusCode.value()))
+    }
+
+    @Recover
+    open fun recoverResourceAccess(ex: ResourceAccessException): OrganisasjonRespons {
+        logger.error("Tilgangsfeil mot $TJENESTE_NAVN: ${ex.message}")
+        throw EnhetsregisterException(
+            "Kunne ikke nå enhetsregisteret: ${ex.message}",
+            HttpStatus.SERVICE_UNAVAILABLE
+        )
+    }
+
+    private fun parseFeilmelding(body: String): String =
+        try {
+            objectMapper.readTree(body).get("melding")?.asText() ?: body
+        } catch (_: Exception) {
+            body
+        }
+}
+
+class EnhetsregisterException(
+    melding: String,
+    httpStatus: HttpStatus,
+) : ErrorResponseException(httpStatus, asProblemDetail(melding, httpStatus), null) {
+    private companion object {
+        private fun asProblemDetail(
+            melding: String,
+            httpStatus: HttpStatus,
+        ): ProblemDetail {
+            val problemDetail = ProblemDetail.forStatus(httpStatus)
+            problemDetail.title = "Feil ved kall mot enhetsregisteret"
+            problemDetail.detail = melding
+
+            problemDetail.type = URI("/problem-details/enhetsregisteret")
+
+            return problemDetail
+        }
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/OrganisasjonNavnRespons.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/OrganisasjonNavnRespons.kt
@@ -1,0 +1,3 @@
+package no.nav.ung.deltakelseopplyser.integration.enhetsregisteret
+
+data class OrganisasjonNavnRespons(val sammensattnavn: String?)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/OrganisasjonRespons.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/OrganisasjonRespons.kt
@@ -1,0 +1,7 @@
+package no.nav.ung.deltakelseopplyser.integration.enhetsregisteret
+
+data class OrganisasjonRespons(val navn: OrganisasjonNavnRespons?) {
+    fun hentNavn(): String? {
+        return navn?.sammensattnavn
+    }
+}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -139,6 +139,7 @@ no.nav:
     ung-sak: # Settes i nais/<cluster>.json
     pdl-api-base-url: # Settes i nais/<cluster>.json
     sokos-kontoregister-person-base-url: # Settes i nais/<cluster>.json
+    enhetsregister-base-url: # Settes i nais/<cluster>.json
 
 springdoc:
   api-docs:

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
@@ -19,11 +19,13 @@ import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendRepository
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendService
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendStatus
+import no.nav.ung.deltakelseopplyser.domene.oppgave.OppgaveMapperService
 import no.nav.ung.deltakelseopplyser.domene.oppgave.OppgaveService
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.soknad.kafka.Ungdomsytelsesøknad
 import no.nav.ung.deltakelseopplyser.integration.abac.SifAbacPdpService
+import no.nav.ung.deltakelseopplyser.integration.enhetsregisteret.EnhetsregisterService
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngSakService
@@ -60,7 +62,8 @@ import java.util.*
     RapportertInntektService::class,
     DeltakerappConfig::class,
     MicrofrontendService::class,
-    OppgaveService::class
+    OppgaveService::class,
+    OppgaveMapperService::class
 )
 class UngdomsytelsesøknadServiceTest {
 
@@ -78,6 +81,9 @@ class UngdomsytelsesøknadServiceTest {
 
     @MockkBean
     lateinit var mineSiderService: MineSiderService
+
+    @MockkBean
+    lateinit var enhetsregisterService: EnhetsregisterService
 
     @Autowired
     lateinit var ungdomsprogramDeltakelseRepository: UngdomsprogramDeltakelseRepository

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregister/EnhetsregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregister/EnhetsregisterServiceTest.kt
@@ -1,0 +1,120 @@
+package no.nav.ung.deltakelseopplyser.integration.enhetsregister
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.ninjasquad.springmockk.MockkBean
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import no.nav.ung.deltakelseopplyser.integration.enhetsregisteret.EnhetsregisterException
+import no.nav.ung.deltakelseopplyser.integration.enhetsregisteret.EnhetsregisterService
+import no.nav.ung.deltakelseopplyser.utils.TokenTestUtils.mockContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock
+import org.springframework.http.HttpStatus
+import org.springframework.retry.ExhaustedRetryException
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.net.URI
+
+@AutoConfigureWireMock
+@EnableMockOAuth2Server
+@ExtendWith(SpringExtension::class)
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class EnhetsregisterServiceTest {
+
+    @Autowired
+    lateinit var enhetsregisterService: EnhetsregisterService
+
+    @Autowired
+    lateinit var wireMockServer: WireMockServer
+
+    @MockkBean
+    private lateinit var springTokenValidationContextHolder: SpringTokenValidationContextHolder
+
+    @BeforeEach
+    fun setUp() {
+        springTokenValidationContextHolder.mockContext()
+    }
+
+    private companion object {
+        val ENHETSREGISTER_BASE_PATH = "/enhetsregister-mock/v2/organisasjon"
+    }
+
+    @Test
+    fun `Forventer info gitt OK respons`() {
+        mockHentOrganisasjonsinfo(
+            statusKode = HttpStatus.OK.value(),
+            // language=json
+            body = """
+                {
+                    "navn": {
+                        "sammensattnavn": "NAV FAMILIE- OG PENSJONSYTELSER OSLO"
+                    }
+                }""".trimMargin()
+        )
+
+        val organisasjonRespons = enhetsregisterService.hentOrganisasjonsinfo("123456789")
+        assertThat(organisasjonRespons.navn).isNotNull
+        assertThat(organisasjonRespons.navn!!.sammensattnavn).isEqualTo("NAV FAMILIE- OG PENSJONSYTELSER OSLO")
+    }
+
+    @Test
+    fun `Forventer å kun forsøke 1 gang gitt ikke-funnet respons`() {
+        mockHentOrganisasjonsinfo(
+            statusKode = HttpStatus.NOT_FOUND.value(),
+            // language=json
+            body = """{"melding": "Organisasjon ikke funnet i enhetsregisteret"}"""
+        )
+
+        val exhaustedRetryException =
+            assertThrows<ExhaustedRetryException> { enhetsregisterService.hentOrganisasjonsinfo("123456789") }
+        assertThat(exhaustedRetryException.cause).isInstanceOf(EnhetsregisterException::class.java)
+
+        verifiserAntallKall(1, "$ENHETSREGISTER_BASE_PATH/123456789")
+    }
+
+    @Test
+    fun `Forventer at det kastes feil ved andre feil`() {
+        mockHentOrganisasjonsinfo(
+            statusKode = HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            body = """{"melding": "Noe har gått galt"}"""
+        )
+
+        val enhetsregisterException =
+            assertThrows<EnhetsregisterException> { enhetsregisterService.hentOrganisasjonsinfo("123456789") }
+        assertThat(enhetsregisterException.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(enhetsregisterException.body.type).isEqualTo(URI("/problem-details/enhetsregisteret"))
+        assertThat(enhetsregisterException.body.title).isEqualTo("Feil ved kall mot enhetsregisteret")
+        assertThat(enhetsregisterException.body.detail).isEqualTo("Annen feil: Noe har gått galt")
+
+        verifiserAntallKall(3, "$ENHETSREGISTER_BASE_PATH/123456789")
+    }
+
+    private fun verifiserAntallKall(antallKall: Int, urlPath: String) {
+        wireMockServer.verify(
+            antallKall,
+            WireMock.getRequestedFor(WireMock.urlPathEqualTo(urlPath))
+        )
+    }
+
+    private fun mockHentOrganisasjonsinfo(statusKode: Int, body: String?) {
+        val responseDefinitionBuilder = WireMock.aResponse()
+            .withStatus(statusKode)
+            .withHeader("Content-Type", "application/json")
+
+        body?.let { responseDefinitionBuilder.withBody(it) }
+
+        wireMockServer.stubFor(
+            WireMock.get(
+                WireMock.urlPathMatching("${ENHETSREGISTER_BASE_PATH}/.*")
+            ).willReturn(responseDefinitionBuilder)
+        )
+    }
+}

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -96,6 +96,7 @@ no.nav:
     sif-abac-pdp: http://localhost:${wiremock.server.port}/sif-abac-pdp-mock
     pdl-api-base-url: http://localhost:${wiremock.server.port}/pdl-api-mock
     sokos-kontoregister-person-base-url: http://localhost:${wiremock.server.port}/sokos-kontoregister-person-mock
+    enhetsregister-base-url: http://localhost:${wiremock.server.port}/enhetsregister-mock
 
 wiremock:
   reset-mappings-after-each-test: true

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
@@ -45,7 +45,7 @@ data class SøkYtelseOppgavetypeDataDTO(
 data class ArbeidOgFrilansRegisterInntektDTO(
     @JsonProperty("inntekt") val inntekt: Int,
     @JsonProperty("arbeidsgiver") val arbeidsgiver: String,
-    @JsonProperty("navn") val navn: String?,
+    @JsonProperty("arbeidsgiverNavn") val arbeidsgiverNavn: String?,
 )
 
 

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/oppgave/felles/OppgavetypeDataDTO.kt
@@ -45,6 +45,7 @@ data class SøkYtelseOppgavetypeDataDTO(
 data class ArbeidOgFrilansRegisterInntektDTO(
     @JsonProperty("inntekt") val inntekt: Int,
     @JsonProperty("arbeidsgiver") val arbeidsgiver: String,
+    @JsonProperty("navn") val navn: String?,
 )
 
 

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -6,7 +6,8 @@
   "minReplicas": "1",
   "maxReplicas": "2",
   "externalHosts": [
-    "pdl-api.dev-fss-pub.nais.io"
+    "pdl-api.dev-fss-pub.nais.io",
+    "ereg-services-q2.dev-fss-pub.nais.io"
   ],
   "ingresses": [
     "https://ung-deltakelse-opplyser.intern.dev.nav.no"
@@ -92,6 +93,8 @@
     "SOKOS_KONTOREGISTER_PERSON_AUDIENCE": "dev-gcp:okonomi:sokos-kontoregister-person",
 
     "UNGDOMSYTELSE_DELTAKER_BASE_URL": "https://ungdomsytelse-deltaker.intern.dev.nav.no/ungdomsprogrammet/ytelsen",
+
+    "NO_NAV_GATEWAYS_ENHETSREGISTER_BASE_URL": "https://ereg-services-q2.dev-fss-pub.nais.io",
 
     "SWAGGER_ENABLED": "true",
     "AZURE_LOGIN_URL": "https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0"

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -6,7 +6,8 @@
   "minReplicas": "2",
   "maxReplicas": "2",
   "externalHosts": [
-    "pdl-api.prod-fss-pub.nais.io"
+    "pdl-api.prod-fss-pub.nais.io",
+    "ereg-services.prod-fss-pub.nais.io"
   ],
   "ingresses": [
     "https://ung-deltakelse-opplyser.intern.nav.no"
@@ -83,6 +84,8 @@
     "SOKOS_KONTOREGISTER_PERSON_AUDIENCE": "prod-gcp:okonomi:sokos-kontoregister-person",
 
     "UNGDOMSYTELSE_DELTAKER_BASE_URL": "https://www.nav.no/ungdomsprogrammet/ytelsen",
+
+    "NO_NAV_GATEWAYS_ENHETSREGISTER_BASE_URL": "https://ereg-services.prod-fss-pub.nais.io",
 
     "SWAGGER_ENABLED": "true",
     "AZURE_LOGIN_URL": "https://login.microsoftonline.com/navno.onmicrosoft.com/oauth2/v2.0"


### PR DESCRIPTION
### **Behov / Bakgrunn**
Oppgaver for kontroll av registerinntekt inneholder kun organisasjonsnummer på arbeidsgiver, og ikke navn.
Deltaker har ikke noe forhold til organisasjonsnummer på arbeidsgiver, og det gjør det vanskeligere å vurdere om opplysningene er riktige.

### **Løsning**
Integrerer mot enhetsregisteret for å hente navn på arbeidsgiver oppgitt i oppgaven for kontroll av registerinntekt.
Det er valgt å gjøre dette kallet i denne tjenesten, og ikke motta den gjennom oppgaven som ung-sak oppretter fordi navn på arbeidsgiver kan endre seg, og man kan dermed få feil visning av navn. Oppslaget gir nåværende navn på arbeidsgiver.

Det er også blitt vurdert om kallene mot enhetsregisteret skal caches for å slippe å gjøre dette kallet mange ganger.
Det er besluttet at dette tilstrekkelig slik det er fordi det ikke kommer til å være mange som kommer til å ha slike oppgaver. 
På sikt kan dette være aktuelt om kallene blir for trege.

### **Andre endringer**
- Erstatter exFun tilDTO med  `OppgaveMapperService` for å mappe `OppgaveDAO` til `OppgaveDTO`, samt populere nødvendige felter via rest og db-kall.
- Utvider `ArbeidOgFrilansRegisterInntektDTO` `navn` felt for å navn på arbeidsgiver.

### **Skjermbilder** (hvis relevant)
