### PR TITLE
Hente enheter fra nom-api for alle veiledere via diagnostikk endepunkt

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -373,7 +373,7 @@
                 <version>${graphql-kotlin.version}</version>
                 <executions>
                     <execution>
-                        <id>generate-graphql-client</id>
+                        <id>generate-pdl-api-graphql-client</id>
                         <goals>
                             <goal>generate-client</goal>
                         </goals>
@@ -381,6 +381,17 @@
                             <packageName>no.nav.pdl.generated</packageName>
                             <schemaFile>${project.basedir}/src/main/resources/pdl/pdl-api-schema.graphql</schemaFile>
                             <queryFileDirectory>${project.basedir}/src/main/resources/pdl</queryFileDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-nom-api-graphql-client</id>
+                        <goals>
+                            <goal>generate-client</goal>
+                        </goals>
+                        <configuration>
+                            <packageName>no.nav.nom.generated</packageName>
+                            <schemaFile>${project.basedir}/src/main/resources/nom/nom-api-schema.graphql</schemaFile>
+                            <queryFileDirectory>${project.basedir}/src/main/resources/nom</queryFileDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/diagnostikk/DiagnostikkDriftController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/diagnostikk/DiagnostikkDriftController.kt
@@ -100,6 +100,10 @@ class DiagnostikkDriftController(
     @Operation(summary = "Hent enheter knyttet til alle nav-identer")
     @ResponseStatus(HttpStatus.OK)
     fun hentEnheterKnyttetNavIdenter(): List<OrgEnhet> {
+        tilgangskontrollService.krevDriftsTilgang(
+            OperasjonDto(ResourceType.DRIFT, BeskyttetRessursActionAttributt.READ, emptySet())
+        )
+
         val alleDeltakelser: List<DeltakelseDAO> = deltakelseRepository.findAll()
         logger.info("Henter enheter for {} deltakelser", alleDeltakelser.size)
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/diagnostikk/DiagnostikkDriftController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/diagnostikk/DiagnostikkDriftController.kt
@@ -100,9 +100,7 @@ class DiagnostikkDriftController(
     @Operation(summary = "Hent enheter knyttet til alle nav-identer")
     @ResponseStatus(HttpStatus.OK)
     fun hentEnheterKnyttetNavIdenter(): List<OrgEnhet> {
-        tilgangskontrollService.krevDriftsTilgang(
-            OperasjonDto(ResourceType.DRIFT, BeskyttetRessursActionAttributt.READ, emptySet())
-        )
+        tilgangskontrollService.krevDriftsTilgang(BeskyttetRessursActionAttributt.READ)
 
         val alleDeltakelser: List<DeltakelseDAO> = deltakelseRepository.findAll()
         logger.info("Henter enheter for {} deltakelser", alleDeltakelser.size)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/diagnostikk/DiagnostikkDriftController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/diagnostikk/DiagnostikkDriftController.kt
@@ -107,7 +107,6 @@ class DiagnostikkDriftController(
                 deltakelseHistorikkService.deltakelseHistorikk(id = deltakelseId)
                     .also { logger.info("Fant totalt {} historikkinnslag", it.size) }
                     .distinctBy { historikk: DeltakelseHistorikk -> historikk.endretAv }
-                    .also { logger.info("Redusert til ${it.size} unike (endretAv) historikkinnslag") }
             }
             .also { historikk ->
                 logger.info(
@@ -121,7 +120,6 @@ class DiagnostikkDriftController(
             .toSet()
 
         val enheter = nomApiService.hentEnheter(unikeNavIdenter)
-        logger.info("Fant totalt {} unike enheter knyttet til {} unike nav-identer", enheter.size, unikeNavIdenter.size)
         return enheter
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkService.kt
@@ -52,7 +52,7 @@ class DeltakelseHistorikkService(
                     endringstype = historikkEndring.endringstype,
                     revisjonsnummer = metadata.revisionNumber.get(),
                     deltakelse = nåværendeRevisjon,
-                    opprettetAv = nåværendeRevisjon.opprettetAv!!,
+                    opprettetAv = nåværendeRevisjon.opprettetAv,
                     opprettetTidspunkt = nåværendeRevisjon.opprettetTidspunkt.atZone(ZoneOffset.UTC),
                     endretAv = nåværendeRevisjon.endretAv,
                     endretTidspunkt = nåværendeRevisjon.endretTidspunkt!!.atZone(ZoneOffset.UTC),

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/AuditorAwareImpl.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/AuditorAwareImpl.kt
@@ -26,6 +26,8 @@ class AuditorAwareImpl(
 
     companion object{
         const val AUDITOR_AWARE_IMPL_BEAN_NAME = "auditorAwareImpl"
+        const val VEILEDER_SUFFIX = " (veileder)"
+        const val DELTAKER_SUFFIX = " (deltaker)"
     }
 
     override fun getCurrentAuditor(): Optional<String> {
@@ -60,9 +62,9 @@ class AuditorAwareImpl(
 
     private fun systemAuditor() = "system"
 
-    private fun SpringTokenValidationContextHolder.veilederAuditor() = "${navIdent()} (veileder)"
+    private fun SpringTokenValidationContextHolder.veilederAuditor() = "${navIdent()}$VEILEDER_SUFFIX"
 
-    private fun SpringTokenValidationContextHolder.deltakerAuditor() = "${personIdent()} (deltaker)"
+    private fun SpringTokenValidationContextHolder.deltakerAuditor() = "${personIdent()}$DELTAKER_SUFFIX"
 
     /**
      * Sjekker om det finnes en gyldig token i context.

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/BaseAuditEntity.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/historikk/BaseAuditEntity.kt
@@ -25,7 +25,7 @@ abstract class BaseAuditEntity {
 
     @CreatedBy
     @Column(name = "opprettet_av", updatable = false)
-    var opprettetAv: String? = null
+    lateinit var opprettetAv: String
 
     @CreatedDate
     @Column(name = "opprettet_tidspunkt", updatable = false)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/nom/api/NomApiClientConfig.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/nom/api/NomApiClientConfig.kt
@@ -1,0 +1,106 @@
+package no.nav.ung.deltakelseopplyser.integration.nom.api
+
+import com.expediagroup.graphql.client.spring.GraphQLWebClient
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties
+import no.nav.ung.deltakelseopplyser.utils.Constants.NAV_CALL_ID
+import no.nav.ung.deltakelseopplyser.utils.Constants.X_CORRELATION_ID
+import no.nav.ung.deltakelseopplyser.utils.MDCUtil
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import reactor.netty.http.client.HttpClient
+import reactor.netty.http.client.HttpClientRequest
+import reactor.netty.http.client.HttpClientResponse
+
+@Configuration
+class NomApiClientConfig(
+    @Value("\${no.nav.gateways.nom-api-base-url}") private val nomApiBaseUrl: String,
+    oauth2Config: ClientConfigurationProperties,
+    private val oAuth2AccessTokenService: OAuth2AccessTokenService,
+) {
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(NomApiClientConfig::class.java)
+    }
+
+    private val azureNomApiClientProperties = oauth2Config.registration["azure-nom-api"]
+        ?: throw RuntimeException("could not find oauth2 client config for azure-nom-api")
+
+    @Bean
+    fun nomApiClient(): GraphQLWebClient = GraphQLWebClient(
+        url = "${nomApiBaseUrl}/graphql",
+        builder = WebClient.builder()
+            .clientConnector(
+                ReactorClientHttpConnector(
+                    HttpClient.create()
+                        .doOnRequest { request: HttpClientRequest, _ ->
+                            logger.info("{} {} {}", request.version(), request.method(), request.resourceUrl())
+                        }
+                        .doOnResponse { response: HttpClientResponse, _ ->
+                            logger.info(
+                                "{} - {} {} {}",
+                                response.status().toString(),
+                                response.version(),
+                                response.method(),
+                                response.resourceUrl()
+                            )
+                        }
+                )
+            )
+            .filter(exchangeBearerTokenFilter())
+            .filter(requestLoggerInterceptor(logger))
+            .filter(requestTracingInterceptor())
+    )
+
+    private fun exchangeBearerTokenFilter() = ExchangeFilterFunction { request: ClientRequest, next: ExchangeFunction ->
+        val accessToken: String = oAuth2AccessTokenService.getAccessToken(azureNomApiClientProperties).access_token
+            ?: throw IllegalStateException("Access token mangler")
+
+        val filtered = ClientRequest.from(request)
+            .headers {
+                it.setBearerAuth(accessToken)
+            }
+            .build()
+
+        next.exchange(filtered)
+    }
+
+    fun requestLoggerInterceptor(logger: Logger) = ExchangeFilterFunction { request: ClientRequest, next: ExchangeFunction ->
+            logger.info("HTTP Request: {} {}", request.method(), request.url())
+
+            val response: Mono<ClientResponse> = next.exchange(request)
+                .doOnNext { response ->
+                    logger.info(
+                        "HTTP Response: {} {} {}",
+                        response.statusCode(),
+                        request.method(),
+                        request.url()
+                    )
+                }
+
+            response
+        }
+
+    fun requestTracingInterceptor() = ExchangeFilterFunction { clientRequest: ClientRequest, next: ExchangeFunction ->
+        val correlationId = MDCUtil.callIdOrNew()
+
+        val filtered = ClientRequest.from(clientRequest)
+            .headers { headers ->
+                headers[NAV_CALL_ID] = correlationId
+                headers[X_CORRELATION_ID] = correlationId
+            }
+            .build()
+
+        next.exchange(filtered)
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/nom/api/NomApiService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/nom/api/NomApiService.kt
@@ -1,0 +1,56 @@
+package no.nav.ung.deltakelseopplyser.integration.nom.api
+
+import com.expediagroup.graphql.client.spring.GraphQLWebClient
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.runBlocking
+import no.nav.nom.generated.HentRessurser
+import no.nav.nom.generated.hentressurser.OrgEnhet
+import no.nav.nom.generated.hentressurser.Ressurs
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class NomApiService(
+    private val nomApiClient: GraphQLWebClient,
+    private val objectMapper: ObjectMapper,
+) {
+    private companion object {
+        private val logger = LoggerFactory.getLogger(NomApiService::class.java)
+    }
+
+    private fun hentRessurser(navIdenter: Set<String>): List<Ressurs> = runBlocking {
+        logger.info("Henter resssurs info for {} navIdenter", navIdenter.size)
+        val response = nomApiClient.execute(HentRessurser(HentRessurser.Variables(navIdenter = navIdenter.toList())))
+
+        if (!response.extensions.isNullOrEmpty()) logger.info("Nom-API response extensions: ${response.extensions}")
+
+        val ressurser = when {
+            !response.errors.isNullOrEmpty() -> {
+                val errorSomJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(response.errors)
+                logger.error("Feil ved henting av ressurser. Årsak: {}", errorSomJson)
+                throw IllegalStateException("Feil ved henting av ressurser.")
+            }
+
+            response.data!!.ressurser.isNotEmpty() -> response.data!!.ressurser.mapNotNull { it.ressurs }
+
+            else -> {
+                error("Feil ved henting av person.")
+            }
+        }
+        if (ressurser.size != navIdenter.size) {
+            logger.warn("Antall hentede ressurser (${ressurser.size}) er ikke lik antall forespurte navIdenter (${navIdenter.size}).")
+        }
+        logger.info("Hentet ${ressurser.size} ressurser fra Nom-API")
+        ressurser
+    }
+
+    fun hentEnheter(navIdenter: Set<String>): List<OrgEnhet> {
+        val enheter = hentRessurser(navIdenter)
+            .flatMap { it.orgTilknytning }
+            .map { it.orgEnhet }
+            .distinctBy { it.remedyEnhetId }
+
+        logger.info("Fant {} unike enheter for {} forespurte navIdenter", enheter.size, navIdenter.size)
+        return enheter
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/nom/api/NomApiService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/nom/api/NomApiService.kt
@@ -44,13 +44,13 @@ class NomApiService(
         ressurser
     }
 
-    fun hentEnheter(navIdenter: Set<String>): List<OrgEnhet> {
-        val enheter = hentRessurser(navIdenter)
-            .flatMap { it.orgTilknytning }
-            .map { it.orgEnhet }
-            .distinctBy { it.remedyEnhetId }
+    fun hentResursserMedEnheter(navIdenter: Set<String>): List<RessursMedEnheter> {
+        val ressursMedEnheter = hentRessurser(navIdenter)
+            .map { RessursMedEnheter(it.navident, it.orgTilknytning.map { orgTilknytning -> orgTilknytning.orgEnhet }) }
 
-        logger.info("Fant {} unike enheter for {} forespurte navIdenter", enheter.size, navIdenter.size)
-        return enheter
+        logger.info("Fant {} unike enheter for {} forespurte navIdenter", ressursMedEnheter.size, navIdenter.size)
+        return ressursMedEnheter
     }
+
+    data class RessursMedEnheter(val navIdent: String, val enheter: List<OrgEnhet>)
 }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -135,11 +135,21 @@ no.nav:
             token-exchange:
               audience: ${SOKOS_KONTOREGISTER_PERSON_AUDIENCE}
 
+          azure-nom-api:
+            token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+            grant-type: client_credentials
+            scope: ${NOM_API_AZURE_SCOPE}
+            authentication:
+              client-auth-method: private_key_jwt
+              client-id: ${AZURE_APP_CLIENT_ID}
+              client-jwk: ${AZURE_APP_JWK}
+
   gateways:
     ung-sak: # Settes i nais/<cluster>.json
     pdl-api-base-url: # Settes i nais/<cluster>.json
     sokos-kontoregister-person-base-url: # Settes i nais/<cluster>.json
     enhetsregister-base-url: # Settes i nais/<cluster>.json
+    nom-api-base-url: # Settes i nais/<cluster>.json
 
 springdoc:
   api-docs:

--- a/app/src/main/resources/nom/hentRessurser.graphql
+++ b/app/src/main/resources/nom/hentRessurser.graphql
@@ -1,8 +1,10 @@
 query HentRessurser($navIdenter: [String!]) {
     ressurser(where: {navidenter: $navIdenter}) {
         ressurs {
+            navident
             orgTilknytning {
                 orgEnhet {
+                    id
                     remedyEnhetId
                     navn
                     gyldigFom

--- a/app/src/main/resources/nom/hentRessurser.graphql
+++ b/app/src/main/resources/nom/hentRessurser.graphql
@@ -1,0 +1,16 @@
+query HentRessurser($navIdenter: [String!]) {
+    ressurser(where: {navidenter: $navIdenter}) {
+        ressurs {
+            orgTilknytning {
+                orgEnhet {
+                    remedyEnhetId
+                    navn
+                    gyldigFom
+                    gyldigTom
+                    orgEnhetsType
+                    agressoOrgenhetType
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/resources/nom/nom-api-schema.graphql
+++ b/app/src/main/resources/nom/nom-api-schema.graphql
@@ -1,0 +1,312 @@
+scalar Date
+scalar JSON
+
+type Query {
+    search(term: String!, ressursFilter: RessursSearchFilter, orgEnhetFilter: OrgEnhetSearchFilter): [SearchResult!]!
+    searchRessurs(term: String!, filter: RessursSearchFilter): [Ressurs!]!
+    searchOrgEnhet(term: String!, filter: OrgEnhetSearchFilter): [OrgEnhet!]!
+    organisasjonsenhet(where: OrgEnhetSearch!): OrgEnhet @deprecated(reason: "Bruk orgEnhet query med samme parametre")
+    orgEnhet(where: OrgEnhetSearch!): OrgEnhet
+    organisasjonsenheter(where: OrgEnheterSearch): [OrgEnhetResult!]! @deprecated(reason: "Bruk orgEnheter query med samme parametre")
+    orgEnheter(where: OrgEnheterSearch): [OrgEnhetResult!]!
+    ressurs(where: RessursSearch!): Ressurs
+    ressurser(where: RessurserSearch): [RessursResult!]!
+    ressurserWithMetadata: [RessursWithMetadataResult!]!
+    person(where: PersonSearch): PersonResult
+}
+
+union SearchResult = Ressurs | OrgEnhet
+
+input RessursSearchFilter {
+    sektorSelection: SektorSelection! = ALLE
+    statusSelection: StatusSelection! = ALLE
+    limit: ResultLimit! = LIMIT_30
+}
+
+input OrgEnhetSearchFilter {
+    orgnivSelection: OrgnivSelection! = ALLE
+    gyldigTomSelection: GyldigTomSelection! = ALLE
+    limit: ResultLimit! = LIMIT_30
+}
+
+input OrgEnhetSearch {
+    agressoId: String
+    orgNiv: String
+    navn: String
+    id: String
+}
+
+input OrgEnheterSearch {
+    agressoIder: [String!]
+    orgEnhetsKategori: [NomNivaa!] @deprecated(reason: "orgEnhetsKategori er erstattet med nomNivaa")
+    nomNivaa: [NomNivaa!]
+    orgNiv: String
+    ider: [String!]
+}
+
+input RessursSearch {
+    navIdent: String    @deprecated(reason: "navIdent er erstattet med navident")
+    navident: String
+    telefonNummer: String
+    personIdent: String     @deprecated(reason: "personIdent er erstattet med personident")
+    personident: String
+}
+
+input RessurserSearch {
+    navIdenter: [String!] @deprecated(reason: "navIdenter er erstattet med navidenter")
+    navidenter: [String!]
+    personIdenter: [String!] @deprecated(reason: "personIdenter er erstattet med personidenter")
+    personidenter: [String!]
+}
+
+input PersonSearch {
+    personIdent: String @deprecated(reason: "personIdent er erstattet med personident")
+    personident: String
+}
+
+type PersonResult {
+    personIdent: String! @deprecated(reason: "personIdent er erstattet med personident")
+    personident: String!
+    navIdent: String @deprecated(reason: "navIdent er erstattet med navident")
+    navident: String
+    person: FolkeregisterPerson @deprecated(reason: "person er erstattet med folkeregisterPerson")
+    folkeregisterPerson: FolkeregisterPerson
+}
+
+type OrgEnhetResult {
+    code: ResultCode!
+    id: String!
+    nomId: String!
+    orgNiv: String
+    organisasjonsenhet: OrgEnhet    @deprecated(reason: "organisasjonsenhet er erstattet med orgEnhet")
+    orgEnhet: OrgEnhet
+}
+
+type RessursResult {
+    code: ResultCode!
+    id: String!
+    ressurs: Ressurs
+}
+
+type RessursWithMetadataResult {
+    code: ResultCode!
+    id: String!
+    ressurs: Ressurs
+    opprettetAv: String
+    opprettetDato: Date
+    endretAv: String
+    endretDato: Date
+    endringEvent: String
+}
+
+enum ResultCode {
+    OK,
+    NOT_FOUND,
+    ERROR
+}
+
+enum SektorSelection{
+    EKSTERN,
+    STATLIG,
+    KOMMUNAL,
+    IKKE_EKSTERN,
+    ALLE,
+}
+
+enum StatusSelection{
+    AKTIV,
+    INAKTIV,
+    ALLE
+}
+
+enum GyldigTomSelection {
+    IKKE_PASSERT,
+    PASSERT,
+    ALLE
+}
+
+enum OrgnivSelection {
+    ORGNIV_ORGENHET,
+    IKKE_ORGNIV_ORGENHET,
+    ALLE
+}
+
+enum ResultLimit {
+    LIMIT_10,
+    LIMIT_20,
+    LIMIT_30,
+    LIMIT_50,
+    LIMIT_100,
+    LIMIT_200,
+    UNLIMITED,
+}
+
+type OrgEnhet {
+
+    id: ID!
+    agressoId: ID!
+    orgNiv: String!
+    agressoOrgenhetType: String
+    navn: String!
+    gyldigFom: Date!
+    gyldigTom: Date
+    organiseringer (retning: Retning) : [Organisering!]!
+    leder: [OrgEnhetsLeder!]!
+    koblinger: [OrgEnhetsKobling!]!
+    orgEnhetsKategori: NomNivaa  @deprecated(reason: "orgEnhetsKategori er erstattet med nomNivaa")
+    nomNivaa: NomNivaa
+    type: Kode   @deprecated(reason: "Ubrukt felt")
+    orgEnhetsType: OrgEnhetsType
+    remedyEnhetId: String
+}
+
+type Organisering {
+    retning: Retning!
+    organisasjonsenhet : OrgEnhet! @deprecated(reason: "organisasjonsenhet er erstattet med orgEnhet")
+    orgEnhet : OrgEnhet!
+    gyldigFom: Date!
+    gyldigTom: Date
+}
+
+type Ressurs {
+    navIdent: String! @deprecated(reason: "navIdent er erstattet med navident")
+    navident: String!
+    personIdent: String! @deprecated(reason: "personIdent er erstattet med personident")
+    personident: String!
+    koblinger: [RessursOrgTilknytning!]! @deprecated(reason: "koblinger er erstatet med orgTilknytning")
+    orgTilknytning: [RessursOrgTilknytning!]!
+    lederFor: [LederOrgEnhet!]!
+    ledere: [RessursLeder!]!
+    person: FolkeregisterPerson  @deprecated(reason: "person er erstatet med folkeregisterPerson")
+    folkeregisterPerson: FolkeregisterPerson
+    epost: String
+    visningsNavn: String @deprecated(reason: "visningsNavn er erstattet med visningsnavn")
+    visningsnavn: String
+    fornavn: String
+    etternavn: String
+    primaryTelefon: String
+    telefon: [Telefon!]!
+    ressurstype: [Sektor!]! @deprecated(reason: "ressurstype er erstatet med sektor")
+    sektor: [Sektor!]!
+    sluttdato: Date @deprecated(reason: "Dårlig datakvalitet, kontakt #nom for mer informasjon før bruk")
+    startdato: Date
+}
+
+type FolkeregisterPerson {
+    navn: Navn!
+}
+
+type Navn {
+    fornavn: String!
+    mellomnavn: String
+    etternavn: String!
+}
+
+type RessursLeder {
+    erDagligOppfolging: Boolean
+    ressurs: Ressurs!
+    gyldigFom: Date!
+    gyldigTom: Date
+}
+
+type OrgEnhetsLeder {
+    ressurs: Ressurs!
+}
+
+type LederOrgEnhet {
+    organisasjonsenhet: OrgEnhet! @deprecated(reason: "organisasjonsenhet er erstattet med orgEnhet")
+    orgEnhet: OrgEnhet!
+    gyldigFom: Date!
+    gyldigTom: Date
+}
+
+type OrgEnhetsKobling {
+    ressurs: Ressurs!
+    gyldigFom: Date!
+    gyldigTom: Date
+}
+
+type RessursOrgTilknytning {
+    organisasjonsenhet: OrgEnhet! @deprecated(reason: "organisasjonsenhet er erstattet med orgEnhet")
+    orgEnhet: OrgEnhet!
+    erDagligOppfolging: Boolean
+    gyldigFom: Date!
+    gyldigTom: Date
+    tilknytningType: TilknytningType
+}
+
+enum Retning {
+    over,
+    under,
+}
+
+type Kode {
+    kode: String!
+    navn: String!
+    gyldigFom: Date
+    gyldigTom: Date
+}
+
+type Telefon {
+    nummer: String!
+    type: TelefonType!
+    beskrivelse: String
+}
+
+enum TelefonType {
+    NAV_TJENESTE_TELEFON,
+    NAV_KONTOR_TELEFON,
+    PRIVAT_TELEFON
+}
+
+enum Sektor {
+    NAV_STATLIG,
+    NAV_KOMMUNAL,
+    EKSTERN
+}
+
+enum AnsettelsesType {
+    FAST,
+    MIDLERTIDIG
+}
+
+enum NomNivaa {
+    LINJEENHET
+    DRIFTSENHET
+    ARBEIDSOMRAADE
+}
+
+enum OrgEnhetsType {
+    ARBEIDSLIVSSENTER
+    NAV_ARBEID_OG_YTELSER
+    ARBEIDSRAADGIVNING
+    DIREKTORAT
+    DIR
+    FYLKE
+    NAV_FAMILIE_OG_PENSJONSYTELSER
+    HJELPEMIDLER_OG_TILRETTELEGGING
+    KLAGEINSTANS
+    NAV_KONTAKTSENTER
+    KONTROLL_KONTROLLENHET
+    NAV_KONTOR
+    TILTAK
+    NAV_OKONOMITJENESTE
+}
+
+enum TilknytningType {
+    ANNET,
+    ARBEIDSTRENING,
+    EKSTERN_SAMARBEIDSPARTNER,
+    FAST,
+    INGEN,
+    JOBBSPESIALIST,
+    KONSULENT,
+    LAERLING,
+    MIDLERTIDIG,
+    PENSJONIST,
+    PRAKSISARBEID,
+    STUDENT,
+    UFORUTSETT_BEHOV,
+    UTDANNINGSSTILLINGER,
+    VIKAR
+}

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -91,12 +91,22 @@ no.nav:
             token-exchange:
               audience: dev-gcp:okonomi:sokos-kontoregister-person
 
+          azure-nom-api:
+            token-endpoint-url: http://localhost:${mock-oauth2-server.port}/oauth2/v2.0/token
+            grant-type: client_credentials
+            scope: api://dev-gcp:nom:nom-api/.default
+            authentication:
+              client-auth-method: private_key_jwt
+              client-id: dev-gcp:k9saksbehandling:ung-deltakelse-opplyser
+              client-jwk: src/test/resources/private_jwk.json
+
   gateways:
     ung-sak: http://localhost:${wiremock.server.port}/ung-sak-mock/k9/sak
     sif-abac-pdp: http://localhost:${wiremock.server.port}/sif-abac-pdp-mock
     pdl-api-base-url: http://localhost:${wiremock.server.port}/pdl-api-mock
     sokos-kontoregister-person-base-url: http://localhost:${wiremock.server.port}/sokos-kontoregister-person-mock
     enhetsregister-base-url: http://localhost:${wiremock.server.port}/enhetsregister-mock
+    nom-api-base-url: http://localhost:${wiremock.server.port}/nom-api-mock
 
 wiremock:
   reset-mappings-after-each-test: true

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -102,6 +102,9 @@
 
     "NO_NAV_GATEWAYS_ENHETSREGISTER_BASE_URL": "https://ereg-services-q2.dev-fss-pub.nais.io",
 
+    "NO_NAV_GATEWAYS_NOM_API_BASE_URL": "https://nom-api.intern.dev.nav.no",
+    "NOM_API_AZURE_SCOPE": "api://dev-gcp.nom.nom-api/.default",
+
     "SWAGGER_ENABLED": "true",
     "AZURE_LOGIN_URL": "https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0"
   }

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -93,6 +93,9 @@
 
     "NO_NAV_GATEWAYS_ENHETSREGISTER_BASE_URL": "https://ereg-services.prod-fss-pub.nais.io",
 
+    "NO_NAV_GATEWAYS_NOM_API_BASE_URL": "https://nom-api.intern.nav.no",
+    "NOM_API_AZURE_SCOPE": "api://prod-gcp.nom.nom-api/.default",
+
     "SWAGGER_ENABLED": "true",
     "AZURE_LOGIN_URL": "https://login.microsoftonline.com/navno.onmicrosoft.com/oauth2/v2.0"
   }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det er ønskelig å vite hvilken enheter(kontorer) som registrerer deltakelse i ungdomsprogrammet.

### **Løsning**
Integrerer mot `nom-api` for å hente ut de enhetene registrert på veilederne som har registrert en deltakelse.
Løsningen brukt nav-identene til veilederne for å spørring mot nom-api, men tar ikke vare på navIdenten i responsen fra spørringen slik at det ikke er en direkte kobling mellom veileder og kontoret de jobber ved.

Formålet med diagnostikkendepunktet er for å kartlegge datakvaliteten i prod da kobling mellom testbruker (veileder) og enhet i testmiljø er veldig dårlig.


### **Andre endringer**
- Setter `opprettetAv` som ikke-nullable da den alltid settes. Gamle data (før mai 2025) i dev-gcp som ikke hadde versjonering er slettet.
