### PR TITLE
Teller antall deltakelser per enhet.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/diagnostikk/DiagnostikkDriftController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/diagnostikk/DiagnostikkDriftController.kt
@@ -15,14 +15,14 @@ import no.nav.sif.abac.kontrakt.person.PersonIdent
 import no.nav.ung.deltakelseopplyser.audit.SporingsloggService
 import no.nav.ung.deltakelseopplyser.config.Issuers
 import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseDAO
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService.Companion.mapToDTO
 import no.nav.ung.deltakelseopplyser.domene.register.historikk.DeltakelseHistorikk
 import no.nav.ung.deltakelseopplyser.domene.register.historikk.DeltakelseHistorikkService
-import no.nav.ung.deltakelseopplyser.historikk.AuditorAwareImpl.Companion.VEILEDER_SUFFIX
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
-import no.nav.ung.deltakelseopplyser.integration.nom.api.NomApiService
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseDTO
+import no.nav.ung.deltakelseopplyser.statistikk.deltakelse.AntallDeltakelsePerEnhetStatistikkRecord
+import no.nav.ung.deltakelseopplyser.statistikk.deltakelse.DeltakelseStatistikkService
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -45,11 +45,11 @@ import java.util.*
     description = "API for å hente informasjon brukt for feilretting. Er sikret med Azure."
 )
 class DiagnostikkDriftController(
-    private val deltakelseRepository: UngdomsprogramDeltakelseRepository,
+    private val deltakelseRepository: DeltakelseRepository,
     private val tilgangskontrollService: TilgangskontrollService,
     private val deltakelseHistorikkService: DeltakelseHistorikkService,
     private val sporingsloggService: SporingsloggService,
-    private val nomApiService: NomApiService,
+    private val deltakelseStatistikkService: DeltakelseStatistikkService
 ) {
     private companion object {
         private val logger = LoggerFactory.getLogger(DiagnostikkDriftController::class.java)
@@ -99,58 +99,10 @@ class DiagnostikkDriftController(
     @GetMapping("/hent/enheter-knyttet-nav-identer", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Hent enheter knyttet til alle nav-identer")
     @ResponseStatus(HttpStatus.OK)
-    fun hentEnheterKnyttetNavIdenter(): DeltakelsePerEnhetResponse {
+    fun hentEnheterKnyttetNavIdenter(): List<AntallDeltakelsePerEnhetStatistikkRecord> {
         tilgangskontrollService.krevDriftsTilgang(BeskyttetRessursActionAttributt.READ)
 
-        val alleDeltakelser: List<DeltakelseDAO> = deltakelseRepository.findAll()
-        logger.info("Henter enheter for {} deltakelser", alleDeltakelser.size)
-
-        val unikeNavIdenterFraDeltakelser: Set<String> = alleDeltakelser
-            .map { deltakelse -> deltakelse.opprettetAv.replace(VEILEDER_SUFFIX, "").trim() }
-            .distinctBy { navIdent -> navIdent }
-            .toSet()
-
-        logger.info(
-            "Fant {} unike NAV-identer fra {} deltakelser",
-            unikeNavIdenterFraDeltakelser.size,
-            alleDeltakelser.size
-        )
-
-        val resursserMedEnheter = nomApiService.hentResursserMedEnheter(unikeNavIdenterFraDeltakelser)
-
-        // Tell antall deltakelser per enhet
-        // Opprett en map fra navIdent til deltakelser
-        val deltakelserPerNavIdent = alleDeltakelser
-            .groupBy { deltakelse -> deltakelse.opprettetAv.replace(VEILEDER_SUFFIX, "").trim() }
-
-        // Tell antall deltakelser per enhet
-        val deltakelserPerEnhet = mutableMapOf<String, Int>()
-
-        resursserMedEnheter.forEach { ressursMedEnheter ->
-            val antallDeltakelserForNavIdent = deltakelserPerNavIdent[ressursMedEnheter.navIdent]?.size ?: 0
-            // Kun tell deltakelser for den første enheten til hver person for å unngå dobbeltelling
-            val enheter = ressursMedEnheter.enheter
-            if (enheter.isNotEmpty() && antallDeltakelserForNavIdent > 0) {
-                val primærenhet = enheter.first()
-                if (enheter.size > 1) {
-                    logger.warn("NAV-ident har ${enheter.size} enheter [${enheter.map { it.navn }}], teller kun på primærenhet ${enheter.first().id} ${enheter.first().navn}")
-                }
-                deltakelserPerEnhet[primærenhet.navn] =
-                    (deltakelserPerEnhet[primærenhet.navn] ?: 0) + antallDeltakelserForNavIdent
-            }
-        }
-
-        return DeltakelsePerEnhetResponse(
-            deltakelserPerEnhet,
-            alleDeltakelser.size,
-            veiledereMedFlereEnheter = resursserMedEnheter
-                .filter { it.enheter.size > 1 }
-                .associate { it.navIdent to it.enheter },
-            resursserMedEnheter
-                .flatMap { it.enheter }
-                .distinctBy { it.id }
-                .toSet()
-        )
+        return deltakelseStatistikkService.antallDeltakelserPerKontorStatistikk()
     }
 
     data class DeltakelsePerEnhetResponse(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseRepository.kt
@@ -1,12 +1,9 @@
 package no.nav.ung.deltakelseopplyser.domene.register
 
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
-import java.time.LocalDate
 import java.util.*
 
-interface UngdomsprogramDeltakelseRepository : JpaRepository<DeltakelseDAO, UUID> {
+interface DeltakelseRepository : JpaRepository<DeltakelseDAO, UUID> {
     fun findByDeltaker_IdIn(deltakerIds: List<UUID>): List<DeltakelseDAO>
 
     fun findByIdAndDeltaker_IdIn(id: UUID, deltakerIds: List<UUID>): DeltakelseDAO?

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -32,7 +32,7 @@ import java.util.*
 
 @Service
 class UngdomsprogramregisterService(
-    private val deltakelseRepository: UngdomsprogramDeltakelseRepository,
+    private val deltakelseRepository: DeltakelseRepository,
     private val deltakerService: DeltakerService,
     private val ungSakService: UngSakService,
     private val pdlService: PdlService,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ungsak/OppgaveUngSakController.kt
@@ -18,7 +18,7 @@ import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.KontrollerRegiste
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.OppgaveDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.RegisterinntektDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.YtelseRegisterInntektDAO
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
@@ -57,7 +57,7 @@ import java.util.*
 class OppgaveUngSakController(
     private val tilgangskontrollService: TilgangskontrollService,
     private val deltakerService: DeltakerService,
-    private val deltakelseRepository: UngdomsprogramDeltakelseRepository,
+    private val deltakelseRepository: DeltakelseRepository,
     private val oppgaveMapperService: OppgaveMapperService,
     private val oppgaveService: OppgaveService,
 ) {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadService.kt
@@ -7,7 +7,7 @@ import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendS
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendStatus
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MinSideMicrofrontendStatusDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.OppgaveService
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.soknad.kafka.Ungdomsytelsesøknad
 import no.nav.ung.deltakelseopplyser.domene.soknad.repository.SøknadRepository
 import no.nav.ung.deltakelseopplyser.domene.soknad.repository.UngSøknadDAO
@@ -22,7 +22,7 @@ import java.util.*
 class UngdomsytelsesøknadService(
     private val søknadRepository: SøknadRepository,
     private val deltakerService: DeltakerService,
-    private val deltakelseRepository: UngdomsprogramDeltakelseRepository,
+    private val deltakelseRepository: DeltakelseRepository,
     private val microfrontendService: MicrofrontendService,
     private val oppgaveService: OppgaveService,
 ) {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/bigquery/BigQueryKlient.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/bigquery/BigQueryKlient.kt
@@ -1,9 +1,16 @@
 package no.nav.ung.deltakelseopplyser.statistikk.bigquery
 
-import com.google.cloud.bigquery.*
+import com.google.cloud.bigquery.BigQuery
+import com.google.cloud.bigquery.BigQueryException
+import com.google.cloud.bigquery.DatasetId
+import com.google.cloud.bigquery.InsertAllRequest
+import com.google.cloud.bigquery.InsertAllResponse
+import com.google.cloud.bigquery.Schema
+import com.google.cloud.bigquery.StandardTableDefinition
+import com.google.cloud.bigquery.TableId
+import com.google.cloud.bigquery.TableInfo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/bigquery/BigQueryMetrikkJobb.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/bigquery/BigQueryMetrikkJobb.kt
@@ -1,7 +1,7 @@
 package no.nav.ung.deltakelseopplyser.statistikk.bigquery
 
-import no.nav.ung.deltakelseopplyser.statistikk.deltaker.AntallDeltakerePerOppgavetypeTabell
 import no.nav.ung.deltakelseopplyser.statistikk.deltaker.AntallDeltakereIUngdomsprogrammetRecord
+import no.nav.ung.deltakelseopplyser.statistikk.deltaker.AntallDeltakerePerOppgavetypeTabell
 import no.nav.ung.deltakelseopplyser.statistikk.deltaker.AntallDeltakereTabell
 import no.nav.ung.deltakelseopplyser.statistikk.deltaker.DeltakerStatistikkService
 import no.nav.ung.deltakelseopplyser.statistikk.oppgave.OppgaveStatistikkService

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/AntallDeltakelsePerEnhetStatistikkRecord.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/AntallDeltakelsePerEnhetStatistikkRecord.kt
@@ -1,4 +1,4 @@
-package no.nav.ung.deltakelseopplyser.statistikk.deltaker
+package no.nav.ung.deltakelseopplyser.statistikk.deltakelse
 
 import com.google.cloud.bigquery.Field
 import com.google.cloud.bigquery.Schema
@@ -8,22 +8,26 @@ import no.nav.ung.deltakelseopplyser.statistikk.bigquery.BigQueryTabell
 import no.nav.ung.deltakelseopplyser.utils.DateUtils
 import java.time.ZonedDateTime
 
-data class AntallDeltakereIUngdomsprogrammetRecord(
-    val antallDeltakere: Long,
+data class AntallDeltakelsePerEnhetStatistikkRecord(
+    val kontor: String,
+    val antallDeltakelser: Int,
     val opprettetTidspunkt: ZonedDateTime,
+
+    val diagnostikk: Map<Any, Any?>, // Brukes for intern diagnostikk, skal ikke lagres i BigQuery.
 ) : BigQueryRecord
 
-
-val AntallDeltakereTabell: BigQueryTabell<AntallDeltakereIUngdomsprogrammetRecord> =
+val AntallDeltakelserPerEnhetTabell: BigQueryTabell<AntallDeltakelsePerEnhetStatistikkRecord> =
     BigQueryTabell(
-        "antall_deltakere_i_ungdomsprogrammet",
+        "antall_deltakere_per_enhet",
         Schema.of(
-            Field.of("antall_deltakere", StandardSQLTypeName.BIGNUMERIC),
+            Field.of("enhet", StandardSQLTypeName.STRING),
+            Field.of("antall_deltakelser", StandardSQLTypeName.BIGNUMERIC),
             Field.of("opprettetTidspunkt", StandardSQLTypeName.DATETIME)
         ),
     ) { rec ->
         mapOf(
-            "antall_deltakere" to rec.antallDeltakere,
+            "enhet" to rec.kontor,
+            "antall_deltakelser" to rec.antallDeltakelser,
             "opprettetTidspunkt" to rec.opprettetTidspunkt.format(DateUtils.DATE_TIME_FORMATTER)
         )
     }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkService.kt
@@ -1,0 +1,105 @@
+package no.nav.ung.deltakelseopplyser.statistikk.deltakelse
+
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseDAO
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
+import no.nav.ung.deltakelseopplyser.historikk.AuditorAwareImpl.Companion.VEILEDER_SUFFIX
+import no.nav.ung.deltakelseopplyser.integration.nom.api.NomApiService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.ZonedDateTime
+
+@Service
+class DeltakelseStatistikkService(
+    private val deltakelseRepository: DeltakelseRepository,
+    private val nomApiService: NomApiService,
+) {
+    private companion object {
+        private val logger = LoggerFactory.getLogger(DeltakelseStatistikkService::class.java)
+    }
+
+    fun antallDeltakelserPerKontorStatistikk(): List<AntallDeltakelsePerEnhetStatistikkRecord> {
+        val kjøringstidspunkt = ZonedDateTime.now()
+
+        val alleDeltakelser: List<DeltakelseDAO> = deltakelseRepository.findAll()
+        logger.info("Henter enheter for {} deltakelser", alleDeltakelser.size)
+
+        // Grupper deltakelser per NAV-ident og hent unike identer i en operasjon
+        val deltakelserPerNavIdent = alleDeltakelser
+            .groupBy { deltakelse -> deltakelse.opprettetAv.replace(VEILEDER_SUFFIX, "").trim() }
+
+        val unikeNavIdenter = deltakelserPerNavIdent.keys
+
+        logger.info(
+            "Fant {} unike NAV-identer fra {} deltakelser",
+            unikeNavIdenter.size,
+            alleDeltakelser.size
+        )
+
+        val resursserMedEnheter = nomApiService.hentResursserMedEnheter(unikeNavIdenter)
+
+        // Teller antall deltakelser per enhet ved å mappe og gruppere på enhetsnavn og
+        val deltakelserPerEnhet = resursserMedEnheter
+            .asSequence()
+            .filter { it.enheter.isNotEmpty() } // Filtrer ut ressurser uten enheter tidlig
+            .map { ressursMedEnheter ->
+                val antallDeltakelserForNavIdent = deltakelserPerNavIdent[ressursMedEnheter.navIdent]?.size ?: 0 // Finn antall deltakelser for denne veilederen
+
+                // Kun tell deltakelser for den første enheten til hver person for å unngå dobbeltelling
+                if (antallDeltakelserForNavIdent > 0) {
+                    val enhet = ressursMedEnheter.enheter.first()
+
+                    // Logg warning for personer med flere enheter
+                    val enhetsnavn = enhet.navn
+                    if (ressursMedEnheter.enheter.size > 1) {
+                        logger.warn("NAV-ident har ${ressursMedEnheter.enheter.size} enheter [${ressursMedEnheter.enheter.map { "${it.id} - ${it.navn}" }}], teller kun på enhet ${enhet.id} - $enhetsnavn")
+                    }
+
+                    enhetsnavn to antallDeltakelserForNavIdent
+                } else {
+                    null
+                }
+            }
+            .filterNotNull()
+            .groupBy({ it.first }, { it.second }) // Gruppér på enhetsnavn
+            .mapValues { (_, antallListe) -> antallListe.sum() } // Summer antall deltakelser per enhet
+
+        // Samle diagnostikk-data for intern bruk
+        val veiledereMedFlereEnheter = resursserMedEnheter
+            .filter { it.enheter.size > 1 }
+            .associate { it.navIdent to it.enheter }
+
+        val antallUnikeEnheter = resursserMedEnheter
+            .flatMap { it.enheter }
+            .distinctBy { it.id }
+            .size
+
+        // Opprett statistikkrecords basert på akkumulerte tellinger
+        return deltakelserPerEnhet.map { (enhetsNavn, antallDeltakelser) ->
+            AntallDeltakelsePerEnhetStatistikkRecord(
+                kontor = enhetsNavn,
+                antallDeltakelser = antallDeltakelser,
+                opprettetTidspunkt = kjøringstidspunkt,
+                diagnostikk = mapOf(
+                    "totalAntallDeltakelser" to alleDeltakelser.size,
+                    "antallUnikeNavIdenter" to unikeNavIdenter.size,
+                    "antallVeiledereMedFlereEnheter" to veiledereMedFlereEnheter,
+                    "antallUnikeEnheter" to antallUnikeEnheter
+                )
+            )
+        }.also {
+            verifiserKonekventTelling(it, alleDeltakelser)
+        }
+    }
+
+    private fun verifiserKonekventTelling(
+        statistikkRecords: List<AntallDeltakelsePerEnhetStatistikkRecord>,
+        alleDeltakelser: List<DeltakelseDAO>,
+    ) {
+        val totalAntallDeltakelserStatistikk = statistikkRecords.sumOf { it.antallDeltakelser }
+        if (totalAntallDeltakelserStatistikk != alleDeltakelser.size) {
+            throw IllegalStateException("Inkonsekvent telling: Total antall deltakelser i statistikk (${totalAntallDeltakelserStatistikk}) stemmer ikke overens med totalt antall deltakelser (${alleDeltakelser.size})")
+        } else {
+            logger.info("Verifisert at total antall deltakelser i statistikk (${totalAntallDeltakelserStatistikk}) stemmer overens med totalt antall deltakelser for enhetene (${alleDeltakelser.size})")
+        }
+    }
+}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltaker/AntallDeltakerePerOppgavetypeRecord.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltaker/AntallDeltakerePerOppgavetypeRecord.kt
@@ -5,8 +5,8 @@ import com.google.cloud.bigquery.Schema
 import com.google.cloud.bigquery.StandardSQLTypeName
 import no.nav.ung.deltakelseopplyser.statistikk.bigquery.BigQueryRecord
 import no.nav.ung.deltakelseopplyser.statistikk.bigquery.BigQueryTabell
+import no.nav.ung.deltakelseopplyser.utils.DateUtils
 import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 
 data class AntallDeltakerePerOppgavetypeRecord(
     val oppgavetype: String,
@@ -29,7 +29,6 @@ val AntallDeltakerePerOppgavetypeTabell: BigQueryTabell<AntallDeltakerePerOppgav
             "antall_deltakere" to rec.antallDeltakere,
             "oppgavetype" to rec.oppgavetype,
             "oppgavestatus" to rec.oppgavestatus,
-            "opprettetTidspunkt" to rec.opprettetTidspunkt
-                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS"))
+            "opprettetTidspunkt" to rec.opprettetTidspunkt.format(DateUtils.DATE_TIME_FORMATTER)
         )
     }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltaker/AntallOppgaverAntallDeltakereFordeling.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltaker/AntallOppgaverAntallDeltakereFordeling.kt
@@ -1,6 +1,0 @@
-package no.nav.ung.deltakelseopplyser.statistikk.deltaker
-
-interface AntallOppgaverAntallDeltakereFordeling {
-    fun getAntallDeltakere(): Long
-    fun getAntallOppgaver(): Long
-}

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/oppgave/OppgaveSvartidRecord.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/oppgave/OppgaveSvartidRecord.kt
@@ -6,6 +6,7 @@ import com.google.cloud.bigquery.StandardSQLTypeName
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
 import no.nav.ung.deltakelseopplyser.statistikk.bigquery.BigQueryRecord
 import no.nav.ung.deltakelseopplyser.statistikk.bigquery.BigQueryTabell
+import no.nav.ung.deltakelseopplyser.utils.DateUtils
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
@@ -37,8 +38,7 @@ val OppgaveSvartidTabell: BigQueryTabell<OppgaveSvartidRecord> =
         mapOf(
             "antall" to rec.antall,
             "svartidAntallDager" to rec.svartidAntallDager,
-            "opprettetTidspunkt" to rec.opprettetTidspunkt
-                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")),
+            "opprettetTidspunkt" to rec.opprettetTidspunkt.format(DateUtils.DATE_TIME_FORMATTER),
             "erLøst" to rec.erLøst,
             "erLukket" to rec.erLukket,
             "ikkeMottattOgEldreEnn14Dager" to rec.ikkeMottattOgEldreEnn14Dager,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/DateUtils.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/DateUtils.kt
@@ -2,8 +2,10 @@ package no.nav.ung.deltakelseopplyser.utils
 
 import java.time.LocalDate
 import java.time.Month
+import java.time.format.DateTimeFormatter
 
 object DateUtils {
+    val DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")
 
     fun LocalDate.måned(): String = when (month) {
         Month.JANUARY -> "januar"

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
@@ -26,18 +26,14 @@ import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.EndretSluttdatoOp
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.EndretStartdatoOppgaveDataDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.KontrollerRegisterInntektOppgaveTypeDataDAO
 import no.nav.ung.deltakelseopplyser.domene.oppgave.repository.SøkYtelseOppgavetypeDataDAO
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.register.ungsak.OppgaveUngSakController
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretSluttdatoDataDTO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.EndretStartdatoDataDTO
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.KontrollerRegisterinntektOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
-import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.SøkYtelseOppgavetypeDataDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektArbeidOgFrilansDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.registerinntekt.RegisterInntektOppgaveDTO
@@ -69,7 +65,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
     lateinit var deltakelseService: UngdomsprogramregisterService
 
     @Autowired
-    lateinit var deltakelseRepository: UngdomsprogramDeltakelseRepository
+    lateinit var deltakelseRepository: DeltakelseRepository
 
     @Autowired
     lateinit var deltakerRepository: DeltakerRepository

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterRepositoryTest.kt
@@ -5,12 +5,9 @@ import jakarta.persistence.EntityManager
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerRepository
 import no.nav.ung.deltakelseopplyser.utils.FødselsnummerGenerator
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -24,7 +21,6 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.LocalDate
-import java.util.*
 import java.util.stream.Stream
 
 
@@ -38,7 +34,7 @@ import java.util.stream.Stream
 class UngdomsprogramregisterRepositoryTest {
 
     @Autowired
-    lateinit var repository: UngdomsprogramDeltakelseRepository
+    lateinit var repository: DeltakelseRepository
 
     @Autowired
     lateinit var deltakerRepository: DeltakerRepository

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -21,7 +21,6 @@ import no.nav.ung.deltakelseopplyser.statistikk.bigquery.BigQueryTestConfigurati
 import no.nav.ung.deltakelseopplyser.utils.FødselsnummerGenerator
 import no.nav.ung.deltakelseopplyser.utils.TokenTestUtils.mockContext
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -58,7 +57,7 @@ class UngdomsprogramregisterServiceTest {
     lateinit var ungdomsprogramregisterService: UngdomsprogramregisterService
 
     @Autowired
-    lateinit var deltakelseRepository: UngdomsprogramDeltakelseRepository
+    lateinit var deltakelseRepository: DeltakelseRepository
 
     @MockkBean
     lateinit var mineSiderService: MineSiderService

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkServiceTest.kt
@@ -10,7 +10,7 @@ import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerRepository
 import no.nav.ung.deltakelseopplyser.domene.minside.MineSiderService
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.register.historikk.DeltakelseHistorikk.Companion.DATE_FORMATTER
 import no.nav.ung.deltakelseopplyser.domene.register.historikk.DeltakelseHistorikk.Companion.DATE_TIME_FORMATTER
@@ -56,7 +56,7 @@ class DeltakelseHistorikkServiceTest {
     private lateinit var deltakerRepository: DeltakerRepository
 
     @Autowired
-    private lateinit var deltakelseRepository: UngdomsprogramDeltakelseRepository
+    private lateinit var deltakelseRepository: DeltakelseRepository
 
     @Autowired
     private lateinit var deltakelseHistorikkService: DeltakelseHistorikkService

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelseOppgavebekreftelseKonsumentTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelseOppgavebekreftelseKonsumentTest.kt
@@ -11,7 +11,7 @@ import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseDTO
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.soknad.repository.SøknadRepository
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
@@ -39,7 +39,7 @@ class UngdomsytelseOppgavebekreftelseKonsumentTest : AbstractIntegrationTest() {
     lateinit var deltakerService: DeltakerService
 
     @SpykBean
-    lateinit var ungdomsprogramDeltakelseRepository: UngdomsprogramDeltakelseRepository
+    lateinit var deltakelseRepository: DeltakelseRepository
 
     @SpykBean
     lateinit var søknadRepository: SøknadRepository
@@ -106,7 +106,7 @@ class UngdomsytelseOppgavebekreftelseKonsumentTest : AbstractIntegrationTest() {
         await.atMost(10, TimeUnit.SECONDS).untilAsserted {
             verify(exactly = 1) { ungdomsytelsesøknadService.håndterMottattSøknad(any()) }
             verify(exactly = 1) { deltakerService.hentDeltakterIder(any()) }
-            verify(exactly = 1) { ungdomsprogramDeltakelseRepository.findByIdAndDeltaker_IdIn(any(), any()) }
+            verify(exactly = 1) { deltakelseRepository.findByIdAndDeltaker_IdIn(any(), any()) }
             verify(exactly = 1) { søknadRepository.save(any()) }
         }
     }

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
@@ -21,7 +21,7 @@ import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendS
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendStatus
 import no.nav.ung.deltakelseopplyser.domene.oppgave.OppgaveMapperService
 import no.nav.ung.deltakelseopplyser.domene.oppgave.OppgaveService
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.soknad.kafka.Ungdomsytelsesøknad
 import no.nav.ung.deltakelseopplyser.integration.abac.SifAbacPdpService
@@ -86,7 +86,7 @@ class UngdomsytelsesøknadServiceTest {
     lateinit var enhetsregisterService: EnhetsregisterService
 
     @Autowired
-    lateinit var ungdomsprogramDeltakelseRepository: UngdomsprogramDeltakelseRepository
+    lateinit var deltakelseRepository: DeltakelseRepository
 
     @Autowired
     lateinit var registerService: UngdomsprogramregisterService
@@ -126,7 +126,7 @@ class UngdomsytelsesøknadServiceTest {
             )
         )
 
-        val deltakelse = ungdomsprogramDeltakelseRepository.findById(deltakelseDTO.id!!)
+        val deltakelse = deltakelseRepository.findById(deltakelseDTO.id!!)
         assertThat(deltakelse)
             .withFailMessage("Forventet å finne deltakelse med id %s", deltakelseDTO.id)
             .isNotEmpty

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/kafka/UngdomsytelsesøknadKonsumentTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/kafka/UngdomsytelsesøknadKonsumentTest.kt
@@ -11,7 +11,7 @@ import no.nav.pdl.generated.hentident.IdentInformasjon
 import no.nav.ung.deltakelseopplyser.AbstractIntegrationTest
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendService
-import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramDeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.soknad.UngdomsytelsesøknadService
 import no.nav.ung.deltakelseopplyser.domene.soknad.repository.SøknadRepository
@@ -48,7 +48,7 @@ class UngdomsytelsesøknadKonsumentTest : AbstractIntegrationTest() {
     lateinit var deltakerService: DeltakerService
 
     @Autowired
-    lateinit var deltakelseRepository: UngdomsprogramDeltakelseRepository
+    lateinit var deltakelseRepository: DeltakelseRepository
 
     @SpykBean
     lateinit var ungdomsytelsesøknadService: UngdomsytelsesøknadService


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi teller deltakelser per NAV-enhet basert på hvilken enhet veilederen tilhører. Dette gir riktig aggregering før vi begynner å publisere metrikken til BigQuery.

### **Løsning**
- Henter alle navidenter som har opprettet deltakelser.

- Slår opp enheten(e) registrert på hver navident.

- Teller deltakelser på den enheten veilederen tilhører.

- Hvis veileder er registrert på flere enheter, bruker vi den første og logger WARN (for å avdekke mulig inkonsistens – dette skal sjelden forekomme).

- Validerer totalsum: summer per enhet skal være lik totalt antall deltakelser. Ved avvik logges feil for å forhindre feilrapportering.

#### Diagnostikk
Utvider diagnostikk-endepunktet med:

- antall deltakelser per enhet

- total antall deltakelser

- flagg for avvik mellom sum per enhet og total

- antall veiledere med >1 enhet (for å overvåke inkonsistens)

Brukes for å verifisere resultatene før publisering til BigQuery. Ingen publisering til BigQuery ennå. Oppdatering av BigQueryMetrikkJobb tas i egen PR etter at diagnostikken er verifisert i prod.

### **Andre endringer**
- Renamer UngdomsprogramdeltakelseRepository til DeltakelseRepository
- Trekker ut dupliserte DateTimeFormatters til utils klasse.
- Sletter ubtukt AntallOppgaverAntallDeltakereFordeling klasse.

### **Skjermbilder** (hvis relevant)
