### PR TITLE
Fikser siste mulige innmeldingsdato.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonlia.kt
@@ -31,7 +31,7 @@ data class DeltakerPersonalia(
     @get:JsonProperty("sisteMuligeInnmeldingsdato")
     val sisteMuligeInnmeldingsdato: LocalDate
         get() {
-            val aldersDatoSiste = fødselsdato.plusYears(29)
+            val aldersDatoSiste = fødselsdato.plusYears(29).minusDays(1) // kan ikke meldes inn etter fylte 29 år
             return programOppstartdato
                 ?.let { maxOf(aldersDatoSiste, it) }
                 ?: aldersDatoSiste

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonliaTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerPersonliaTest.kt
@@ -48,10 +48,10 @@ internal class DeltakerPersonaliaTest {
     }
 
     @Test
-    fun `uten programOppstartdato skal sisteMuligeInnmeldingsdato være fødselsdato + 29 år`() {
+    fun `uten programOppstartdato skal sisteMuligeInnmeldingsdato være fødselsdato + 28 år`() {
         val fødselsdato = LocalDate.of(1996, 5, 10)
         assertEquals(
-            LocalDate.of(2025, 5, 10),
+            LocalDate.of(2025, 5, 9),
             lagDeltakerPersonalia(fødselsdato, null).sisteMuligeInnmeldingsdato
         )
     }
@@ -68,10 +68,10 @@ internal class DeltakerPersonaliaTest {
 
     @Test
     fun `med programOppstartdato tidligere enn sisteMuligeInnmeldingsdato skal alder vinne`() {
-        val fødselsdato = LocalDate.of(1996, 5, 10)
+        val fødselsdato = LocalDate.of(1996, 2, 11)
         val programOppstartdato = LocalDate.of(2025, 1, 1)
         assertEquals(
-            LocalDate.of(2025, 5, 10),
+            LocalDate.of(2025, 2, 10),
             lagDeltakerPersonalia(fødselsdato, programOppstartdato).sisteMuligeInnmeldingsdato
         )
     }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Deltakere som allerede har fylt 29 år skal ikke kunne meldes inn.

### **Løsning**
Flytter sisteMuligeInnmeldingsdato til en dag før deltaker fyller 29 år.

### **Andre endringer**

### **Skjermbilder** (hvis relevant)
