### PR TITLE
Fikser feil i oppslag av identer fra PDL der hisoriske identer ikke ble tatt med.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepository.kt
@@ -6,7 +6,6 @@ import org.springframework.data.repository.query.Param
 import java.util.*
 
 interface DeltakerRepository : JpaRepository<DeltakerDAO, UUID> {
-    fun findByDeltakerIdent(deltakerIdent: String): DeltakerDAO?
     fun findByDeltakerIdentIn(deltakerIdenter: List<String>): List<DeltakerDAO>
 
     @Query(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepository.kt
@@ -6,7 +6,14 @@ import org.springframework.data.repository.query.Param
 import java.util.*
 
 interface DeltakerRepository : JpaRepository<DeltakerDAO, UUID> {
-    fun findByDeltakerIdentIn(deltakerIdenter: List<String>): List<DeltakerDAO>
+    @Query(
+        value = """
+                SELECT d.* FROM deltaker d
+                WHERE d.deltaker_ident IN (:deltakerIdenter)
+            """,
+        nativeQuery = true
+    )
+    fun finnDeltakerGittIdenter(@Param("deltakerIdenter") deltakerIdenter: List<String>): List<DeltakerDAO>
 
     @Query(
         value = """

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -140,7 +140,6 @@ class DeltakerService(
 
     private fun hentDeltakere(deltakerIdentEllerAktørId: String): List<DeltakerDAO> {
         val identer = pdlService.hentFolkeregisteridenter(ident = deltakerIdentEllerAktørId).map { it.ident }
-        logger.info("Fant identer: ${identer.joinToString(", ")} fra PDL") //TOOD: fjerne før prod
         return deltakerRepository.finnDeltakerGittIdenter(identer)
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -70,7 +70,7 @@ class DeltakerService(
     }
 
     fun finnDeltakerGittIdent(deltakerIdent: String): DeltakerDAO? {
-        return deltakerRepository.findByDeltakerIdent(deltakerIdent)
+        return hentDeltakere(deltakerIdent).firstOrNull()
     }
 
     fun finnDeltakerGittId(id: UUID): Optional<DeltakerDAO> {
@@ -121,7 +121,7 @@ class DeltakerService(
     }
 
     private fun hentPdlPerson(deltakerIdent: String): Person {
-        val PdlPerson = kotlin.runCatching { pdlService.hentPerson(deltakerIdent) }
+        val PdlPerson = runCatching { pdlService.hentPerson(deltakerIdent) }
             .fold(
                 onSuccess = { it },
                 onFailure = {
@@ -144,13 +144,13 @@ class DeltakerService(
     }
 
     private fun hentDeltakerInfoMedIdent(deltakerIdent: String): DeltakerPersonalia {
-        val deltakerDAO = deltakerRepository.findByDeltakerIdent(deltakerIdent)
+        val deltaker = hentDeltakere(deltakerIdent).firstOrNull()
 
-        val PdlPerson = hentPdlPerson(deltakerDAO?.deltakerIdent ?: deltakerIdent)
+        val PdlPerson = hentPdlPerson(deltaker?.deltakerIdent ?: deltakerIdent)
         val diskresjonskoder: Set<Diskresjonskode> = sifAbacPdpService.hentDiskresjonskoder(PersonIdent.fra(deltakerIdent))
 
         return DeltakerPersonalia(
-            id = deltakerDAO?.id,
+            id = deltaker?.id,
             deltakerIdent = deltakerIdent,
             navn = PdlPerson.navn.first(),
             fødselsdato = PdlPerson.foedselsdato.first().toLocalDate(),

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -140,6 +140,7 @@ class DeltakerService(
 
     private fun hentDeltakere(deltakerIdentEllerAktørId: String): List<DeltakerDAO> {
         val identer = pdlService.hentFolkeregisteridenter(ident = deltakerIdentEllerAktørId).map { it.ident }
+        logger.info("Fant identer: ${identer.joinToString(", ")} fra PDL") //TOOD: fjerne før prod
         return deltakerRepository.finnDeltakerGittIdenter(identer)
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerService.kt
@@ -140,7 +140,7 @@ class DeltakerService(
 
     private fun hentDeltakere(deltakerIdentEllerAktørId: String): List<DeltakerDAO> {
         val identer = pdlService.hentFolkeregisteridenter(ident = deltakerIdentEllerAktørId).map { it.ident }
-        return deltakerRepository.findByDeltakerIdentIn(identer)
+        return deltakerRepository.finnDeltakerGittIdenter(identer)
     }
 
     private fun hentDeltakerInfoMedIdent(deltakerIdent: String): DeltakerPersonalia {
@@ -149,6 +149,9 @@ class DeltakerService(
         val PdlPerson = hentPdlPerson(deltaker?.deltakerIdent ?: deltakerIdent)
         val diskresjonskoder: Set<Diskresjonskode> = sifAbacPdpService.hentDiskresjonskoder(PersonIdent.fra(deltakerIdent))
 
+        if (deltaker == null) {
+            logger.info("Fant ikke deltaker med ident. Returnerer kun personinfo fra PDL.")
+        }
         return DeltakerPersonalia(
             id = deltaker?.id,
             deltakerIdent = deltakerIdent,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -256,7 +256,7 @@ class UngdomsprogramregisterService(
         requireNotNull(opphørsdato) { "Til og med dato må være satt for å sende inn hendelse til ung-sak" }
 
         logger.info("Henter aktørIder for deltaker")
-        val aktørIder = pdlService.hentAktørIder(oppdatert.deltaker.deltakerIdent, historisk = true)
+        val aktørIder = pdlService.hentAktørIder(oppdatert.deltaker.deltakerIdent)
         val nåværendeAktørId = aktørIder.first { !it.historisk }.ident
 
         logger.info("Sender inn hendelse til ung-sak om at deltaker har opphørt programmet")
@@ -283,7 +283,7 @@ class UngdomsprogramregisterService(
         val startdato = oppdatert.getFom()
 
         logger.info("Henter aktørIder for deltaker")
-        val aktørIder = pdlService.hentAktørIder(oppdatert.deltaker.deltakerIdent, historisk = true)
+        val aktørIder = pdlService.hentAktørIder(oppdatert.deltaker.deltakerIdent)
         val nåværendeAktørId = aktørIder.first { !it.historisk }.ident
 
         logger.info("Sender inn hendelse til ung-sak om at programmet har endret startdato")

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/abac/SifAbacPpdKlientKonfig.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/abac/SifAbacPpdKlientKonfig.kt
@@ -3,6 +3,7 @@ package no.nav.ung.deltakelseopplyser.integration.abac
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
 import no.nav.ung.deltakelseopplyser.http.MDCValuesPropagatingClientHttpRequestInterceptor
+import no.nav.ung.deltakelseopplyser.utils.RestTemplateUtils.requestLoggerInterceptor
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -45,7 +46,7 @@ class SifAbacPpdKlientKonfig(
             .defaultHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .rootUri(sifAbacPdpUrl)
             .defaultMessageConverters()
-            .interceptors(bearerTokenInterceptor(), mdcInterceptor)
+            .interceptors(bearerTokenInterceptor(), mdcInterceptor, requestLoggerInterceptor(logger))
             .build()
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/EnhetsregisterKlientKonfig.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/enhetsregisteret/EnhetsregisterKlientKonfig.kt
@@ -1,6 +1,7 @@
 package no.nav.ung.deltakelseopplyser.integration.enhetsregisteret
 
 import no.nav.ung.deltakelseopplyser.http.MDCValuesPropagatingClientHttpRequestInterceptor
+import no.nav.ung.deltakelseopplyser.utils.RestTemplateUtils.requestLoggerInterceptor
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -33,7 +34,7 @@ class EnhetsregisterKlientKonfig(
             .defaultHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .rootUri(enhetsregisterBaseUrl)
             .defaultMessageConverters()
-            .interceptors(mdcInterceptor)
+            .interceptors(mdcInterceptor, requestLoggerInterceptor(logger))
             .build()
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterKlientKonfig.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/kontoregister/KontoregisterKlientKonfig.kt
@@ -3,6 +3,7 @@ package no.nav.ung.deltakelseopplyser.integration.kontoregister
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
 import no.nav.ung.deltakelseopplyser.http.MDCValuesPropagatingClientHttpRequestInterceptor
+import no.nav.ung.deltakelseopplyser.utils.RestTemplateUtils.requestLoggerInterceptor
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -45,7 +46,7 @@ class KontoregisterKlientKonfig(
             .defaultHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .rootUri(kontoregisterBaseUrl)
             .defaultMessageConverters()
-            .interceptors(bearerTokenInterceptor(), mdcInterceptor)
+            .interceptors(bearerTokenInterceptor(), mdcInterceptor, requestLoggerInterceptor(logger))
             .build()
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/pdl/api/PdlService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/pdl/api/PdlService.kt
@@ -40,7 +40,7 @@ class PdlService(
         }
     }
 
-    fun hentIdenter(ident: String, historisk: Boolean = false): Identliste = runBlocking {
+    fun hentIdenter(ident: String): Identliste = runBlocking {
         val response = pdlClient.execute(HentIdent(HentIdent.Variables(ident)))
 
         if (!response.extensions.isNullOrEmpty()) logger.info("PDL response extensions: ${response.extensions}")
@@ -52,9 +52,7 @@ class PdlService(
                 throw IllegalStateException("Feil ved henting av identListe.")
             }
 
-            response.data!!.hentIdenter != null -> response.data!!.hentIdenter!!.identer
-                .filter { historisk || !it.historisk }
-                .let { Identliste(it) }
+            response.data!!.hentIdenter != null -> Identliste(response.data!!.hentIdenter!!.identer)
 
             else -> {
                 error("Feil ved henting av person.")
@@ -67,14 +65,14 @@ class PdlService(
         return identliste.identer.filter { it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }
     }
 
-    fun hentAktørIder(ident: String, historisk: Boolean = false): List<IdentInformasjon> {
-        val identliste = hentIdenter(ident = ident, historisk = historisk)
+    fun hentAktørIder(ident: String): List<IdentInformasjon> {
+        val identliste = hentIdenter(ident = ident)
         return runCatching {
             identliste.identer.filter { it.gruppe == IdentGruppe.AKTORID }
         }
             .getOrElse {
-                logger.error("Fant ingen aktørIder. Historisk=$historisk")
-                throw IllegalStateException("Fant ingen historiske aktørId. Historisk=$historisk")
+                logger.error("Fant ingen aktørIder.")
+                throw IllegalStateException("Fant ingen historiske aktørId.")
             }
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/ungsak/UngSakKlientKonfig.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/ungsak/UngSakKlientKonfig.kt
@@ -3,6 +3,7 @@ package no.nav.ung.deltakelseopplyser.integration.ungsak
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
 import no.nav.security.token.support.client.spring.ClientConfigurationProperties
 import no.nav.ung.deltakelseopplyser.http.MDCValuesPropagatingClientHttpRequestInterceptor
+import no.nav.ung.deltakelseopplyser.utils.RestTemplateUtils.requestLoggerInterceptor
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -45,7 +46,7 @@ class UngSakKlientKonfig(
             .defaultHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .rootUri(ungSakUrl)
             .defaultMessageConverters()
-            .interceptors(bearerTokenInterceptor(), mdcInterceptor)
+            .interceptors(bearerTokenInterceptor(), mdcInterceptor, requestLoggerInterceptor(logger))
             .build()
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/RestTemplateUtils.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/utils/RestTemplateUtils.kt
@@ -1,0 +1,16 @@
+package no.nav.ung.deltakelseopplyser.utils
+
+import org.slf4j.Logger
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+
+object RestTemplateUtils {
+    fun requestLoggerInterceptor(logger: Logger) =
+        ClientHttpRequestInterceptor { request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution ->
+            logger.info("HTTP Request: {} {}", request.method, request.uri)
+            val response = execution.execute(request, body)
+            logger.info("HTTP Response: {} {} {}", response.statusCode, request.method, request.uri)
+            response
+        }
+}

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepositoryTest.kt
@@ -9,8 +9,6 @@ import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.OppgaveStatus
 import no.nav.ung.deltakelseopplyser.kontrakt.oppgave.felles.Oppgavetype
 import no.nav.ung.deltakelseopplyser.utils.FødselsnummerGenerator
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
@@ -113,7 +111,7 @@ class DeltakerRepositoryTest {
         entityManager.persist(deltaker)
         entityManager.flush()
 
-        val oppdatertDeltaker = deltakerRepository.findByDeltakerIdentIn(listOf(deltaker.deltakerIdent)).firstOrNull()?.let {
+        val oppdatertDeltaker = deltakerRepository.finnDeltakerGittIdenter(listOf(deltaker.deltakerIdent)).firstOrNull()?.let {
             assertThat(it.oppgaver).isNotEmpty
             val oppgaveDAO = it.oppgaver.first()
             oppgaveDAO.markerSomLøst()

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/deltaker/DeltakerRepositoryTest.kt
@@ -113,7 +113,7 @@ class DeltakerRepositoryTest {
         entityManager.persist(deltaker)
         entityManager.flush()
 
-        val oppdatertDeltaker = deltakerRepository.findByDeltakerIdent(deltaker.deltakerIdent)?.let {
+        val oppdatertDeltaker = deltakerRepository.findByDeltakerIdentIn(listOf(deltaker.deltakerIdent)).firstOrNull()?.let {
             assertThat(it.oppgaver).isNotEmpty
             val oppgaveDAO = it.oppgaver.first()
             oppgaveDAO.markerSomLøst()

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/oppgave/OppgaveServiceTest.kt
@@ -102,7 +102,7 @@ class OppgaveServiceTest : AbstractIntegrationTest() {
 
     @BeforeEach
     fun setUpEach() {
-        every { pdlService.hentAktørIder(any(), any()) } returns listOf(
+        every { pdlService.hentAktørIder(any()) } returns listOf(
             IdentInformasjon(
                 ident = deltakerAktørId,
                 historisk = false,

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -208,7 +208,7 @@ class UngdomsprogramregisterServiceTest {
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
-        val deltakerDAO = deltakerRepository.findByDeltakerIdentIn(listOf(innmelding.deltaker.deltakerIdent)).firstOrNull()
+        val deltakerDAO = deltakerRepository.finnDeltakerGittIdenter(listOf(innmelding.deltaker.deltakerIdent)).firstOrNull()
         assertThat(deltakerDAO).isNotNull
         assertThat(deltakelseRepository.findByDeltaker_IdIn(listOf(innmelding.deltaker.id!!))).isNotEmpty
 

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -235,7 +235,7 @@ class UngdomsprogramregisterServiceTest {
 
     @Test
     fun `Endring av startdato på deltakelse oppretter BEKREFT_ENDRET_STARTDATO oppgave`() {
-        every { pdlService.hentAktørIder(any(), true) } returns listOf(
+        every { pdlService.hentAktørIder(any()) } returns listOf(
             IdentInformasjon("321", false, IdentGruppe.AKTORID),
             IdentInformasjon("451", true, IdentGruppe.AKTORID)
         )
@@ -262,7 +262,7 @@ class UngdomsprogramregisterServiceTest {
 
     @Test
     fun `Endring av startdato til før første mulige innmeldingsdato gir valideringsfeil`() {
-        every { pdlService.hentAktørIder(any(), true) } returns listOf(
+        every { pdlService.hentAktørIder(any()) } returns listOf(
             IdentInformasjon("321", false, IdentGruppe.AKTORID),
             IdentInformasjon("451", true, IdentGruppe.AKTORID)
         )
@@ -298,7 +298,7 @@ class UngdomsprogramregisterServiceTest {
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
-        every { pdlService.hentAktørIder(any(), true) } returns listOf(
+        every { pdlService.hentAktørIder(any()) } returns listOf(
             IdentInformasjon("321", false, IdentGruppe.AKTORID),
             IdentInformasjon("451", true, IdentGruppe.AKTORID)
         )
@@ -332,7 +332,7 @@ class UngdomsprogramregisterServiceTest {
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
-        every { pdlService.hentAktørIder(any(), true) } returns listOf(
+        every { pdlService.hentAktørIder(any()) } returns listOf(
             IdentInformasjon("321", false, IdentGruppe.AKTORID),
             IdentInformasjon("451", true, IdentGruppe.AKTORID)
         )

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -208,7 +208,7 @@ class UngdomsprogramregisterServiceTest {
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
-        val deltakerDAO = deltakerRepository.findByDeltakerIdent(innmelding.deltaker.deltakerIdent)
+        val deltakerDAO = deltakerRepository.findByDeltakerIdentIn(listOf(innmelding.deltaker.deltakerIdent)).firstOrNull()
         assertThat(deltakerDAO).isNotNull
         assertThat(deltakelseRepository.findByDeltaker_IdIn(listOf(innmelding.deltaker.id!!))).isNotEmpty
 

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkServiceTest.kt
@@ -90,7 +90,7 @@ class DeltakelseHistorikkServiceTest {
 
     @Test
     fun `Deltaker blir meldt inn i programmet, startdato endres, deltaker søker ytelse, og deretter meldes deltaker ut av programmet`() {
-        every { pdlService.hentAktørIder(any(), true) } returns listOf(
+        every { pdlService.hentAktørIder(any()) } returns listOf(
             IdentInformasjon("321", false, IdentGruppe.AKTORID),
             IdentInformasjon("451", true, IdentGruppe.AKTORID)
         )
@@ -218,7 +218,7 @@ class DeltakelseHistorikkServiceTest {
 
     @Test
     fun `Flere endringer på engang skal føre til feil ved henting av historikk`() {
-        every { pdlService.hentAktørIder(any(), true) } returns listOf(
+        every { pdlService.hentAktørIder(any()) } returns listOf(
             IdentInformasjon("321", false, IdentGruppe.AKTORID),
             IdentInformasjon("451", true, IdentGruppe.AKTORID)
         )


### PR DESCRIPTION
### **Behov / Bakgrunn**
Søk på deltaker med historiske identer (fnr/dnr) traff ikke dersom deltakeren var registrert med dnr i databasen. Selv om vi hadde tatt høyde for historiske fnr/dnr i databasespørringer, var et flagg av ved henting av historiske identer fra PDL (dnr → fnr). Dermed fikk vi alltid kun siste ident (fnr) fra PDL og traff ikke på deltakere registrert med dnr.

### **Løsning**
- Flagget for henting av historiske identer er fjernet da vi alltid ønsker også historiske identer. Nå gir søk med både fnr og dnr samme deltaker og deltakelse i deltaker/veileder-portalen. 
- Flere steder hentet vi deltaker med forespurt ident. Endret det overalt slik at vi alltid henter alle identer for identen som blir forespurt før vi gjør andre spørringer mot databasen.

### **Andre endringer**
- Legger på request/response logging på alle utgående restkall.
- Skriver om JPQL spørring til native spørring.

### **Skjermbilder** (hvis relevant)
#### Spørring med DNR
<img width="1457" height="916" alt="image" src="https://github.com/user-attachments/assets/a6d23852-6a36-4e71-96b8-4f61f69bd645" />

#### Spørring med FNR
<img width="1457" height="916" alt="image" src="https://github.com/user-attachments/assets/8b781add-3b0a-4832-b730-a8f5079f70ed" />

