### PR TITLE
Fiks inkonsekvent telling i deltakelse-statistikk med "Enhet sikkerhetsnett"-kategori

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,33 @@ Andre applikasjoner i SiF-porteføljen bør gjøre selvstendige vurderinger om H
 
 # 6. Data
 
+## Statistikk: Deltakelser per enhet
+
+Tjenesten publiserer statistikk over antall deltakelser per NAV-enhet til BigQuery. Hver deltakelse mappes til enheten som veilederen (som opprettet deltakelsen) tilhørte på opprettelsestidspunktet, basert på data fra [NOM API](https://nom.nav.no/).
+
+### "Enhet sikkerhetsnett"
+
+Noen deltakelser kan ikke mappes til en spesifikk enhet. Disse telles under kategorien **"Enhet sikkerhetsnett"** i stedet for å bli droppet fra tellingen. Dette sikrer at summen av alle enheter alltid er lik det totale antallet deltakelser.
+
+Årsaker til at en deltakelse havner under "Enhet sikkerhetsnett":
+
+| Årsak | Forklaring |
+|-------|-----------|
+| **Ressurs ikke funnet i NOM** | Veilederens NAV-ident finnes ikke i NOM API. Kan skyldes at veilederen har sluttet eller at identen ikke er registrert. |
+| **Ingen gyldig enhet på dato** | Veilederen finnes i NOM, men ingen av enhetstilknytningene (inkludert fallback) dekker datoen deltakelsen ble opprettet. Typisk ved gap i NOM-data ved enhetsbytte. |
+
+Et høyt antall "Enhet sikkerhetsnett" tyder på datakvalitetsproblemer i NOM. Diagnostikk-data inkluderer hvilke NAV-identer som er berørt, slik at NOM-data kan korrigeres.
+
+### Toleranseperiode (fallback)
+
+Når en veileder bytter enhet, kan det oppstå et gap i NOM der den gamle tilknytningen har utløpt men den nye ikke er registrert ennå. For å håndtere dette brukes en **toleranseperiode på 90 dager**: hvis ingen enhet er gyldig på opprettelsesdatoen, velges den sist utløpte tilknytningen — forutsatt at den utløp innen de siste 90 dagene.
+
+Eksempel:
+- Veileder har tilknytning til "NAV Oslo" som utløp 30. september
+- Ny tilknytning til "NAV Bergen" registreres først 20. oktober
+- Deltakelse opprettet 9. oktober → mappes til "NAV Oslo" via fallback (gap på 9 dager < 90 dager)
+
+
 # 7. Infrastrukturarkitektur
 
 ## System Context Diagram

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
@@ -21,8 +21,9 @@ data class DeltakelsePerEnhetResultat(
 )
 
 class DeltakelsePerEnhetStatistikkTeller {
-    private companion object {
+    companion object {
         private val logger = LoggerFactory.getLogger(DeltakelsePerEnhetStatistikkTeller::class.java)
+        const val ENHET_SIKKERHETSNETT = "Enhet sikkerhetsnett"
     }
 
     fun tellAntallDeltakelserPerEnhet(
@@ -31,15 +32,17 @@ class DeltakelsePerEnhetStatistikkTeller {
     ): DeltakelsePerEnhetResultat {
         val ressursLookup = ressurserMedTilknytninger.associateBy { it.navIdent }
         val veiledereMedFlereEnheter = mutableMapOf<String, List<OrgEnhetMedPeriode>>()
+        val deltakelserUtenEnhet = mutableListOf<DeltakelseInput>()
 
         val deltakelserPerEnhet = deltakelser
-            .mapNotNull { deltakelse ->
+            .map { deltakelse ->
                 finnEnhetForDeltakelse(deltakelse, ressursLookup, ressurserMedTilknytninger, veiledereMedFlereEnheter)
+                    ?: ENHET_SIKKERHETSNETT.also { deltakelserUtenEnhet.add(deltakelse) }
             }
             .groupingBy { it }
             .eachCount()
 
-        return opprettResultat(deltakelser, deltakelserPerEnhet, veiledereMedFlereEnheter, ressurserMedTilknytninger)
+        return opprettResultat(deltakelser, deltakelserPerEnhet, veiledereMedFlereEnheter, ressurserMedTilknytninger, deltakelserUtenEnhet)
     }
 
     private fun finnEnhetForDeltakelse(
@@ -49,31 +52,32 @@ class DeltakelsePerEnhetStatistikkTeller {
         veiledereMedFlereEnheter: MutableMap<String, List<OrgEnhetMedPeriode>>,
     ): String? {
         val navIdent = deltakelse.navIdent()
+        val ressurs = ressursLookup[navIdent]
 
-        return ressursLookup[navIdent]?.let { ressurs ->
-            val gyldigeEnheter = finnGyldigeEnheter(ressurs, deltakelse.opprettetDato)
-
-            when {
-                gyldigeEnheter.isEmpty() -> {
-                    logger.warn("Fant ingen gyldig enhet for NAV-ident $navIdent på tidspunkt ${deltakelse.opprettetDato}")
-                    null
-                }
-
-                gyldigeEnheter.size == 1 -> gyldigeEnheter.first().navn
-                else -> {
-                    val valgtEnhet = velgMestPopulæreEnhet(
-                        gyldigeEnheter,
-                        alleRessurser,
-                        navIdent,
-                        deltakelse.opprettetDato,
-                        veiledereMedFlereEnheter
-                    )
-                    valgtEnhet.navn
-                }
-            }
-        } ?: run {
+        if (ressurs == null) {
             logger.warn("Fant ingen ressurs for NAV-ident $navIdent")
-            null
+            return null
+        }
+
+        val gyldigeEnheter = finnGyldigeEnheter(ressurs, deltakelse.opprettetDato)
+
+        return when {
+            gyldigeEnheter.isEmpty() -> {
+                logger.warn("Fant ingen gyldig enhet for NAV-ident $navIdent på tidspunkt ${deltakelse.opprettetDato}")
+                null
+            }
+
+            gyldigeEnheter.size == 1 -> gyldigeEnheter.first().navn
+            else -> {
+                val valgtEnhet = velgMestPopulæreEnhet(
+                    gyldigeEnheter,
+                    alleRessurser,
+                    navIdent,
+                    deltakelse.opprettetDato,
+                    veiledereMedFlereEnheter
+                )
+                valgtEnhet.navn
+            }
         }
     }
 
@@ -92,8 +96,10 @@ class DeltakelsePerEnhetStatistikkTeller {
             return eksaktGyldigeEnheter
         }
 
-        // Fallback: Finn siste gyldige enhet innen toleranseperiode (30 dager)
-        val toleranseDager = 30L
+        // Fallback: Finn siste gyldige enhet innen toleranseperiode (90 dager).
+        // Toleranseperioden overbrygger korte gap i NOM-data som oppstår ved enhetsbytte,
+        // der den nye tilknytningen ikke er registrert ennå.
+        val toleranseDager = 90L
 
         val sisteGyldigeEnhet = ressurs.orgTilknytninger
             .filter { tilknytning ->
@@ -167,6 +173,7 @@ class DeltakelsePerEnhetStatistikkTeller {
         deltakelserPerEnhet: Map<String, Int>,
         veiledereMedFlereEnheter: Map<String, List<OrgEnhetMedPeriode>>,
         ressurserMedTilknytninger: List<RessursMedAlleTilknytninger>,
+        deltakelserUtenEnhet: List<DeltakelseInput>,
     ): DeltakelsePerEnhetResultat {
         val antallUnikeNavIdenter = deltakelser
             .map { it.navIdent() }
@@ -175,13 +182,25 @@ class DeltakelsePerEnhetStatistikkTeller {
 
         logger.info("Fant $antallUnikeNavIdenter unike NAV-identer fra ${deltakelser.size} deltakelser")
 
+        if (deltakelserUtenEnhet.isNotEmpty()) {
+            val berørteNavIdenter = deltakelserUtenEnhet.map { it.navIdent() }.toSet()
+            logger.warn(
+                "${deltakelserUtenEnhet.size} deltakelser kunne ikke mappes til en enhet og er telt under '$ENHET_SIKKERHETSNETT'. " +
+                        "Berørte NAV-identer: $berørteNavIdenter"
+            )
+        }
+
         return DeltakelsePerEnhetResultat(
             deltakelserPerEnhet = deltakelserPerEnhet,
             diagnostikk = mapOf(
                 "enhetPopularitet" to beregnEnhetPopularitet(ressurserMedTilknytninger),
                 "veiledereMedFlereEnheter" to veiledereMedFlereEnheter,
                 "totalAntallDeltakelser" to deltakelser.size,
-                "antallUnikeNavIdenter" to antallUnikeNavIdenter
+                "antallUnikeNavIdenter" to antallUnikeNavIdenter,
+                "deltakelserUtenEnhet" to mapOf(
+                    "antall" to deltakelserUtenEnhet.size,
+                    "berørteNavIdenter" to deltakelserUtenEnhet.map { it.navIdent() }.toSet()
+                )
             )
         )
     }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
@@ -7,11 +7,16 @@ import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.util.*
 
+/**
+ * Input til statistikkberegning. Representerer én deltakelse med info om hvem som opprettet den og når.
+ * [opprettetAv] inneholder veilederens ident med suffiks, f.eks. "H111111 (veileder)".
+ */
 data class DeltakelseInput(
     val id: UUID,
     val opprettetAv: String,
     val opprettetDato: LocalDate,
 ) {
+    /** Ekstraher ren NAV-ident ved å fjerne " (veileder)"-suffiks. */
     fun navIdent() = opprettetAv.removeSuffix(VEILEDER_SUFFIX).trim()
 }
 
@@ -20,31 +25,57 @@ data class DeltakelsePerEnhetResultat(
     val diagnostikk: Map<Any, Any?> = emptyMap(),
 )
 
+/**
+ * Teller antall deltakelser per NAV-enhet.
+ *
+ * Tellingen fungerer slik:
+ * 1. Hver deltakelse mappes til enheten veilederen tilhørte på opprettelsestidspunktet (via NOM).
+ * 2. Hvis veilederen hadde flere gyldige enheter på datoen, velges den mest populære (flest veiledere totalt).
+ * 3. Hvis ingen enhet er gyldig på eksakt dato, brukes en fallback med 90-dagers toleranse.
+ * 4. Deltakelser som ikke kan mappes til noen enhet, telles under [ENHET_SIKKERHETSNETT]
+ *    slik at totalsummen alltid stemmer med antall input-deltakelser.
+ */
 class DeltakelsePerEnhetStatistikkTeller {
     companion object {
         private val logger = LoggerFactory.getLogger(DeltakelsePerEnhetStatistikkTeller::class.java)
         const val ENHET_SIKKERHETSNETT = "Enhet sikkerhetsnett"
     }
 
+    /**
+     * Hovedmetode: Teller antall deltakelser gruppert per enhetsnavn.
+     * Returnerer et resultat der summen av alle verdier alltid er lik [deltakelser].size.
+     */
     fun tellAntallDeltakelserPerEnhet(
         deltakelser: List<DeltakelseInput>,
         ressurserMedTilknytninger: List<RessursMedAlleTilknytninger>,
     ): DeltakelsePerEnhetResultat {
+        // Oppslag-map for rask lookup av NOM-ressurs per NAV-ident
         val ressursLookup = ressurserMedTilknytninger.associateBy { it.navIdent }
         val veiledereMedFlereEnheter = mutableMapOf<String, List<OrgEnhetMedPeriode>>()
         val deltakelserUtenEnhet = mutableListOf<DeltakelseInput>()
 
+        // Map hver deltakelse til et enhetsnavn. Hvis ingen enhet finnes, brukes ENHET_SIKKERHETSNETT
+        // som fallback slik at ingen deltakelser går tapt fra tellingen.
         val deltakelserPerEnhet = deltakelser
             .map { deltakelse ->
                 finnEnhetForDeltakelse(deltakelse, ressursLookup, ressurserMedTilknytninger, veiledereMedFlereEnheter)
                     ?: ENHET_SIKKERHETSNETT.also { deltakelserUtenEnhet.add(deltakelse) }
             }
+            // Grupper enhetsnavn og tell forekomster: "NAV Oslo" -> 82, "NAV Bergen" -> 67, osv.
             .groupingBy { it }
             .eachCount()
 
         return opprettResultat(deltakelser, deltakelserPerEnhet, veiledereMedFlereEnheter, ressurserMedTilknytninger, deltakelserUtenEnhet)
     }
 
+    /**
+     * Finner enhetsnavn for én deltakelse. Returnerer null hvis ingen enhet kan bestemmes.
+     *
+     * Steg:
+     * 1. Slå opp veilederens NAV-ident i NOM-ressursene.
+     * 2. Finn gyldige enheter på deltakelsens opprettelsesdato (inkl. fallback).
+     * 3. Hvis flere gyldige enheter, velg den mest populære blant alle veiledere.
+     */
     private fun finnEnhetForDeltakelse(
         deltakelse: DeltakelseInput,
         ressursLookup: Map<String, RessursMedAlleTilknytninger>,
@@ -54,20 +85,24 @@ class DeltakelsePerEnhetStatistikkTeller {
         val navIdent = deltakelse.navIdent()
         val ressurs = ressursLookup[navIdent]
 
+        // Veilederen finnes ikke i NOM — kan skyldes at de har sluttet eller ikke er registrert
         if (ressurs == null) {
             logger.warn("Fant ingen ressurs for NAV-ident $navIdent")
             return null
         }
 
+        // Finn enheter som var gyldige på tidspunktet deltakelsen ble opprettet
         val gyldigeEnheter = finnGyldigeEnheter(ressurs, deltakelse.opprettetDato)
 
         return when {
+            // Ingen gyldige enheter funnet, heller ikke via fallback
             gyldigeEnheter.isEmpty() -> {
                 logger.warn("Fant ingen gyldig enhet for NAV-ident $navIdent på tidspunkt ${deltakelse.opprettetDato}")
                 null
             }
-
+            // Nøyaktig én gyldig enhet — bruk den direkte
             gyldigeEnheter.size == 1 -> gyldigeEnheter.first().navn
+            // Flere gyldige enheter — velg den mest populære for å disambiguere
             else -> {
                 val valgtEnhet = velgMestPopulæreEnhet(
                     gyldigeEnheter,
@@ -81,34 +116,45 @@ class DeltakelsePerEnhetStatistikkTeller {
         }
     }
 
+    /**
+     * Finner gyldige enheter for en veileder på en gitt dato.
+     *
+     * Bruker to strategier:
+     * 1. **Eksakt match**: Både tilknytning og orgEnhet må være gyldig på datoen.
+     * 2. **Fallback (90 dager)**: Hvis ingen eksakt match, brukes den sist utløpte tilknytningen
+     *    som sluttet innen 90 dager før datoen. Dette dekker gap i NOM ved enhetsbytte.
+     */
     private fun finnGyldigeEnheter(
         ressurs: RessursMedAlleTilknytninger,
         opprettetDato: LocalDate,
     ): List<OrgEnhetMedPeriode> {
-        // Først: Prøv å finne enheter som er gyldige på eksakt tidspunkt
+        // Strategi 1: Finn enheter der BÅDE tilknytningen og selve orgEnheten er gyldig på datoen.
+        // Dobbeltsjekken er nødvendig fordi en tilknytning kan være aktiv selv om enheten er nedlagt.
         val eksaktGyldigeEnheter = ressurs.orgTilknytninger
-            .filter { it.erGyldigPåTidspunkt(opprettetDato) }
+            .filter { it.erGyldigPåTidspunkt(opprettetDato) }    // Er tilknytningen gyldig?
             .map { it.orgEnhet }
-            .filter { it.erGyldigPåTidspunkt(opprettetDato) }
+            .filter { it.erGyldigPåTidspunkt(opprettetDato) }    // Er selve enheten gyldig?
             .distinctBy { "${it.id}-${it.navn}" }
 
         if (eksaktGyldigeEnheter.isNotEmpty()) {
             return eksaktGyldigeEnheter
         }
 
-        // Fallback: Finn siste gyldige enhet innen toleranseperiode (90 dager).
+        // Strategi 2 (fallback): Finn siste gyldige enhet innen toleranseperiode.
         // Toleranseperioden overbrygger korte gap i NOM-data som oppstår ved enhetsbytte,
-        // der den nye tilknytningen ikke er registrert ennå.
+        // der den gamle tilknytningen har utløpt men den nye ikke er registrert ennå.
         val toleranseDager = 90L
 
         val sisteGyldigeEnhet = ressurs.orgTilknytninger
             .filter { tilknytning ->
-                // Tilknytningen må ha startet før opprettelsesdato
+                // Tilknytningen må ha startet før (eller på) opprettelsesdatoen
                 !tilknytning.gyldigFom.isAfter(opprettetDato) &&
-                        // Enheten må ha sluttet nylig (innen toleranseperiode)
+                        // Tilknytningen må ha en sluttdato (dvs. den har utløpt)
                         tilknytning.gyldigTom != null &&
+                        // Sluttdatoen må ikke ligge mer enn 90 dager før opprettelsesdatoen
                         !tilknytning.gyldigTom.isBefore(opprettetDato.minusDays(toleranseDager))
             }
+            // Velg den som utløp sist (mest sannsynlig riktig enhet)
             .sortedByDescending { it.gyldigTom }
             .take(1)
             .map { it.orgEnhet }
@@ -126,6 +172,12 @@ class DeltakelsePerEnhetStatistikkTeller {
         return emptyList()
     }
 
+    /**
+     * Når en veileder har flere gyldige enheter på samme dato, velges den enheten
+     * som flest veiledere totalt er tilknyttet. Dette er en heuristikk for å finne
+     * den "riktige" enheten (typisk ungdomsteamet) fremfor sekundærtilknytninger
+     * (f.eks. kontaktsenter, regionkontor).
+     */
     private fun velgMestPopulæreEnhet(
         gyldigeEnheter: List<OrgEnhetMedPeriode>,
         alleRessurser: List<RessursMedAlleTilknytninger>,
@@ -133,7 +185,9 @@ class DeltakelsePerEnhetStatistikkTeller {
         opprettetDato: LocalDate,
         veiledereMedFlereEnheter: MutableMap<String, List<OrgEnhetMedPeriode>>,
     ): OrgEnhetMedPeriode {
+        // Tell hvor mange tilknytninger hver enhet har totalt på tvers av alle veiledere
         val enhetPopularitet = beregnEnhetPopularitet(alleRessurser)
+        // Velg enheten med flest tilknytninger totalt
         val mestPopulæreEnhet = gyldigeEnheter.maxByOrNull {
             enhetPopularitet["${it.id}-${it.navn}"] ?: 0
         } ?: gyldigeEnheter.first()
@@ -144,6 +198,10 @@ class DeltakelsePerEnhetStatistikkTeller {
         return mestPopulæreEnhet
     }
 
+    /**
+     * Beregner popularitet per enhet: antall ganger enheten forekommer som tilknytning
+     * på tvers av alle veiledere. Brukes for å disambiguere når en veileder har flere enheter.
+     */
     private fun beregnEnhetPopularitet(ressurserMedTilknytninger: List<RessursMedAlleTilknytninger>): Map<String, Int> =
         ressurserMedTilknytninger
             .flatMap { it.orgTilknytninger }
@@ -168,6 +226,7 @@ class DeltakelsePerEnhetStatistikkTeller {
         )
     }
 
+    /** Bygger resultatet med diagnostikk-data for feilsøking og overvåkning. */
     private fun opprettResultat(
         deltakelser: List<DeltakelseInput>,
         deltakelserPerEnhet: Map<String, Int>,
@@ -183,6 +242,7 @@ class DeltakelsePerEnhetStatistikkTeller {
         logger.info("Fant $antallUnikeNavIdenter unike NAV-identer fra ${deltakelser.size} deltakelser")
 
         if (deltakelserUtenEnhet.isNotEmpty()) {
+            // Logg hvilke veiledere som ikke kunne mappes — indikerer datakvalitetsproblemer i NOM
             val berørteNavIdenter = deltakelserUtenEnhet.map { it.navIdent() }.toSet()
             logger.warn(
                 "${deltakelserUtenEnhet.size} deltakelser kunne ikke mappes til en enhet og er telt under '$ENHET_SIKKERHETSNETT'. " +

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkBeregnerTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkBeregnerTest.kt
@@ -124,8 +124,10 @@ class DeltakelseStatistikkBeregnerTest {
         // Når vi beregner antall deltakelser per enhet
         val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
 
-        // Da skal kun deltakelsen fra ABC123 telles
+        // Da skal deltakelsen fra ABC123 telles under NAV Oslo,
+        // og deltakelsen fra UNKNOWN telles under "Enhet sikkerhetsnett"
         assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Oslo", 1)
+        assertThat(resultat.deltakelserPerEnhet).containsEntry(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT, 1)
     }
 
     @Test
@@ -223,16 +225,17 @@ class DeltakelseStatistikkBeregnerTest {
 
     @Test
     fun `skal håndtere enheter som ikke er gyldige på deltakelsestidspunkt`() {
-        // Gitt en deltakelse hvor ingen enheter er gyldige på deltakelsesdatoen
+        // Gitt en deltakelse hvor ingen enheter er gyldige på deltakelsesdatoen,
+        // og gapet er større enn toleranseperioden (90 dager)
         val deltakelser = listOf(
-            DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2024-06-15"))
+            DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2024-08-15"))
         )
 
         val ressurserMedTilknytninger = listOf(
             RessursMedAlleTilknytninger(
                 navIdent = "ABC123",
                 orgTilknytninger = listOf(
-                    // Tilknytning som var gyldig før deltakelsesdato
+                    // Tilknytning som utløp mer enn 90 dager før deltakelsesdato
                     RessursOrgTilknytningMedPeriode(
                         gyldigFom = LocalDate.parse("2024-01-01"),
                         gyldigTom = LocalDate.parse("2024-03-31"),
@@ -250,7 +253,7 @@ class DeltakelseStatistikkBeregnerTest {
                         orgEnhet = OrgEnhetMedPeriode(
                             id = "1002",
                             navn = "NAV Bergen",
-                            gyldigFom = LocalDate.parse("2024-07-01"), // Starter etter deltakelsesdato
+                            gyldigFom = LocalDate.parse("2024-09-01"), // Starter etter deltakelsesdato
                             gyldigTom = null
                         )
                     )
@@ -261,8 +264,10 @@ class DeltakelseStatistikkBeregnerTest {
         // Når vi beregner antall deltakelser per enhet
         val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
 
-        // Da skal ingen deltakelser telles (ingen enheter var gyldige på tidspunktet)
-        assertThat(resultat.deltakelserPerEnhet).isEmpty()
+        // Da skal deltakelsen telles under "Enhet sikkerhetsnett" siden ingen enheter var gyldige på tidspunktet
+        assertThat(resultat.deltakelserPerEnhet).containsEntry(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT, 1)
+        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey("NAV Oslo")
+        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey("NAV Bergen")
     }
 
     @Test
@@ -418,6 +423,62 @@ class DeltakelseStatistikkBeregnerTest {
         // fordi den var siste gyldige enhet veilederen hadde
         assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Oslo", 1)
         assertThat(resultat.deltakelserPerEnhet).doesNotContainKey("NAV Bergen")
+    }
+
+    @Test
+    fun `summen av alle enheter skal alltid være lik antall input-deltakelser`() {
+        // Gitt en blanding av deltakelser med og uten gyldig enhet
+        val deltakelser = listOf(
+            DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2024-01-15")),
+            DeltakelseInput(UUID.randomUUID(), "UNKNOWN$VEILEDER_SUFFIX", LocalDate.parse("2024-01-16")),
+            DeltakelseInput(UUID.randomUUID(), "DEF456$VEILEDER_SUFFIX", LocalDate.parse("2024-08-15")) // Ingen gyldig enhet på dato (gap > 90 dager)
+        )
+
+        val ressurserMedTilknytninger = listOf(
+            RessursMedAlleTilknytninger(
+                navIdent = "ABC123",
+                orgTilknytninger = listOf(
+                    RessursOrgTilknytningMedPeriode(
+                        gyldigFom = LocalDate.parse("2024-01-01"),
+                        gyldigTom = null,
+                        orgEnhet = OrgEnhetMedPeriode(
+                            id = "1001",
+                            navn = "NAV Oslo",
+                            gyldigFom = LocalDate.parse("2020-01-01"),
+                            gyldigTom = null
+                        )
+                    )
+                )
+            ),
+            RessursMedAlleTilknytninger(
+                navIdent = "DEF456",
+                orgTilknytninger = listOf(
+                    RessursOrgTilknytningMedPeriode(
+                        gyldigFom = LocalDate.parse("2024-01-01"),
+                        gyldigTom = LocalDate.parse("2024-03-31"),
+                        orgEnhet = OrgEnhetMedPeriode(
+                            id = "1002",
+                            navn = "NAV Bergen",
+                            gyldigFom = LocalDate.parse("2020-01-01"),
+                            gyldigTom = LocalDate.parse("2024-03-31")
+                        )
+                    )
+                )
+            )
+            // UNKNOWN mangler i ressursene
+        )
+
+        // Når vi beregner antall deltakelser per enhet
+        val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
+
+        // Da skal summen av alle enheter (inkludert "Enhet sikkerhetsnett") alltid være lik antall input-deltakelser
+        val totalSum = resultat.deltakelserPerEnhet.values.sum()
+        assertThat(totalSum).isEqualTo(deltakelser.size)
+
+        // Og diagnostikken skal vise de umappede deltakelsene
+        @Suppress("UNCHECKED_CAST")
+        val deltakelserUtenEnhet = resultat.diagnostikk["deltakelserUtenEnhet"] as Map<String, Any>
+        assertThat(deltakelserUtenEnhet["antall"]).isEqualTo(2) // UNKNOWN (ikke i NOM) + DEF456 (ingen gyldig enhet på dato)
     }
 
 }


### PR DESCRIPTION
## Behov / Bakgrunn

Scheduled task for publisering av deltakelse-statistikk feiler med:
```
Inkonsekvent telling: Total antall deltakelser i statistikk (547) stemmer ikke overens med totalt antall deltakelser (591)
```

Rotårsaken er at 9 veiledere har org-tilknytninger i NOM som ikke dekker datoene deltakelsene ble opprettet. `.mapNotNull` i `DeltakelsePerEnhetStatistikkTeller` dropper ~44 deltakelser stille, slik at summen ikke stemmer.

I tillegg gir en Kotlin `?.let { null } ?: run { }` pattern villedende logging — "Fant ingen ressurs for NAV-ident" logges selv når ressursen finnes i NOM, men ingen gyldig enhet dekker datoen.

## Løsning

- **"Enhet sikkerhetsnett"-kategori**: Erstattet `.mapNotNull` med `.map` + fallback til `"Enhet sikkerhetsnett"`. Alle deltakelser telles nå, og summen stemmer alltid.
- **Fikset logging-bug**: Erstattet `?.let { } ?: run { }` med eksplisitt null-sjekk (`val ressurs = ressursLookup[navIdent]` + `if (ressurs == null)`), slik at "Fant ingen ressurs" kun logges når ressursen faktisk mangler.
- **Økt toleranseperiode fra 30 til 90 dager**: Dekker typiske gap i NOM-data ved enhetsbytte uten å risikere attribusjon til veldig gamle/nedlagte enheter.
- **Utvidet diagnostikk**: Ny `deltakelserUtenEnhet`-seksjon med antall og berørte NAV-identer, pluss warning-logg.

## Andre endringer

- Oppdatert README med dokumentasjon om statistikk-logikken: hva "Enhet sikkerhetsnett" betyr, hvorfor toleranseperioden eksisterer, og hva man bør gjøre ved høyt antall.
- Oppdatert og lagt til tester som verifiserer at summen alltid stemmer og at diagnostikk inkluderer umappede deltakelser.
