### PR TITLE
Fiks deltakelser per enhet

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ Et høyt antall "Enhet sikkerhetsnett" tyder på datakvalitetsproblemer i NOM. D
 
 ### Toleranseperiode (fallback)
 
-Når en veileder bytter enhet, kan det oppstå et gap i NOM der den gamle tilknytningen har utløpt men den nye ikke er registrert ennå. For å håndtere dette brukes en **toleranseperiode på 90 dager**: hvis ingen enhet er gyldig på opprettelsesdatoen, velges den sist utløpte tilknytningen — forutsatt at den utløp innen de siste 90 dagene.
+Når en veileder bytter enhet, kan det oppstå et gap i NOM. For å håndtere dette brukes en **toleranseperiode på 90 dager** i to retninger:
 
-Eksempel:
-- Veileder har tilknytning til "NAV Oslo" som utløp 30. september
-- Ny tilknytning til "NAV Bergen" registreres først 20. oktober
-- Deltakelse opprettet 9. oktober → mappes til "NAV Oslo" via fallback (gap på 9 dager < 90 dager)
+1. **Bakover-fallback**: Hvis ingen enhet er gyldig på opprettelsesdatoen, velges den sist utløpte tilknytningen — forutsatt at den utløp innen de siste 90 dagene.
+2. **Fremover-fallback**: Hvis heller ingen nylig utløpt tilknytning finnes, velges den tidligste fremtidige tilknytningen — forutsatt at den starter innen 90 dager. Dette dekker tilfeller der veilederen jobber ved enheten men NOM-registreringen kom etter at deltakelsen ble opprettet.
+
+Eksempel bakover: Tilknytning til "NAV Oslo" utløp 30. sep → deltakelse opprettet 9. okt → mappes til "NAV Oslo" (gap 9 dager < 90).
+Eksempel fremover: Tilknytning til "Skien Oppfølging ung" starter 20. okt → deltakelse opprettet 9. okt → mappes til "Skien" (gap 11 dager < 90).
 
 
 # 7. Infrastrukturarkitektur

--- a/README.md
+++ b/README.md
@@ -49,30 +49,31 @@ Andre applikasjoner i SiF-porteføljen bør gjøre selvstendige vurderinger om H
 
 ## Statistikk: Deltakelser per enhet
 
-Tjenesten publiserer statistikk over antall deltakelser per NAV-enhet til BigQuery. Hver deltakelse mappes til enheten som veilederen (som opprettet deltakelsen) tilhørte på opprettelsestidspunktet, basert på data fra [NOM API](https://nom.nav.no/).
+Tjenesten publiserer statistikk over antall deltakelser per NAV-enhet til BigQuery. Hver deltakelse mappes til enheten som veilederen (som opprettet deltakelsen) tilhørte på opprettelsestidspunktet.
+
+### Koblingstabell (primærkilde)
+
+Når en deltakelse opprettes, lagres veilederens enhet i en koblingstabell (`deltakelse_veileder_enhet`) som et point-in-time snapshot. Dette gjør statistikken uavhengig av fremtidige endringer i NOM — f.eks. at veilederen bytter enhet eller slutter i NAV.
+
+For historiske deltakelser (opprettet før koblingstabellen) kan man kjøre backfill via diagnostikk-endepunktet `POST /diagnostikk/backfill/deltakelse-veileder-enhet`. Deltakelser der backfill feiler (f.eks. veileder har sluttet og har tom `orgTilknytning`) kan korrigeres manuelt via `PUT /diagnostikk/deltakelse-veileder-enhet/{deltakelseId}`.
+
+### NOM-fallback (sekundærkilde)
+
+Deltakelser som ikke finnes i koblingstabellen faller tilbake til oppslag mot [NOM API](https://nom.nav.no/). To strategier brukes i prioritert rekkefølge:
+
+1. **Eksakt match**: Veilederens tilknytning og enheten må begge være gyldige på opprettelsesdatoen.
+2. **Nærmeste tilknytning**: Velger tilknytningen med korteste absolutte avstand til datoen. Dekker gap ved enhetsbytte og sen NOM-registrering.
 
 ### "Enhet sikkerhetsnett"
 
-Noen deltakelser kan ikke mappes til en spesifikk enhet. Disse telles under kategorien **"Enhet sikkerhetsnett"** i stedet for å bli droppet fra tellingen. Dette sikrer at summen av alle enheter alltid er lik det totale antallet deltakelser.
-
-Årsaker til at en deltakelse havner under "Enhet sikkerhetsnett":
+Deltakelser som ikke kan mappes til en enhet — verken via koblingstabell eller NOM — telles under kategorien **"Enhet sikkerhetsnett"**. Dette sikrer at summen av alle enheter alltid er lik det totale antallet deltakelser.
 
 | Årsak | Forklaring |
 |-------|-----------|
-| **Ressurs ikke funnet i NOM** | Veilederens NAV-ident finnes ikke i NOM API. Kan skyldes at veilederen har sluttet eller at identen ikke er registrert. |
-| **Ingen gyldig enhet på dato** | Veilederen finnes i NOM, men ingen av enhetstilknytningene (inkludert fallback) dekker datoen deltakelsen ble opprettet. Typisk ved gap i NOM-data ved enhetsbytte. |
+| **Ingen kobling og ressurs ikke funnet i NOM** | Veilederens NAV-ident finnes ikke i NOM API. Kan skyldes at veilederen har sluttet. |
+| **Ingen kobling og tom orgTilknytning** | Veilederen finnes i NOM, men har ingen tilknytninger (har sluttet). |
 
-Et høyt antall "Enhet sikkerhetsnett" tyder på datakvalitetsproblemer i NOM. Diagnostikk-data inkluderer hvilke NAV-identer som er berørt, slik at NOM-data kan korrigeres.
-
-### Toleranseperiode (fallback)
-
-Når en veileder bytter enhet, kan det oppstå et gap i NOM. For å håndtere dette brukes en **toleranseperiode på 90 dager** i to retninger:
-
-1. **Bakover-fallback**: Hvis ingen enhet er gyldig på opprettelsesdatoen, velges den sist utløpte tilknytningen — forutsatt at den utløp innen de siste 90 dagene.
-2. **Fremover-fallback**: Hvis heller ingen nylig utløpt tilknytning finnes, velges den tidligste fremtidige tilknytningen — forutsatt at den starter innen 90 dager. Dette dekker tilfeller der veilederen jobber ved enheten men NOM-registreringen kom etter at deltakelsen ble opprettet.
-
-Eksempel bakover: Tilknytning til "NAV Oslo" utløp 30. sep → deltakelse opprettet 9. okt → mappes til "NAV Oslo" (gap 9 dager < 90).
-Eksempel fremover: Tilknytning til "Skien Oppfølging ung" starter 20. okt → deltakelse opprettet 9. okt → mappes til "Skien" (gap 11 dager < 90).
+Et høyt antall "Enhet sikkerhetsnett" kan løses ved å kjøre backfill og/eller bruke PUT-endepunktet for manuell korrigering.
 
 
 # 7. Infrastrukturarkitektur

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetDAO.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetDAO.kt
@@ -1,0 +1,29 @@
+package no.nav.ung.deltakelseopplyser.domene.register
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.*
+
+@Entity
+@Table(name = "deltakelse_veileder_enhet")
+class DeltakelseVeilederEnhetDAO(
+    @Id
+    @Column(name = "deltakelse_id")
+    val deltakelseId: UUID,
+
+    @Column(name = "nav_ident", nullable = false)
+    val navIdent: String,
+
+    @Column(name = "enhet_id", nullable = false)
+    var enhetId: String,
+
+    @Column(name = "enhet_navn", nullable = false)
+    var enhetNavn: String,
+
+    @Column(name = "opprettet_tidspunkt", nullable = false, updatable = false)
+    val opprettetTidspunkt: Instant = Instant.now(),
+)
+

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetRepository.kt
@@ -1,0 +1,10 @@
+package no.nav.ung.deltakelseopplyser.domene.register
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface DeltakelseVeilederEnhetRepository : JpaRepository<DeltakelseVeilederEnhetDAO, UUID> {
+    fun findAllByDeltakelseIdIn(deltakelseIder: List<UUID>): List<DeltakelseVeilederEnhetDAO>
+    fun findByDeltakelseId(deltakelseId: UUID): DeltakelseVeilederEnhetDAO?
+}
+

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetService.kt
@@ -1,0 +1,219 @@
+package no.nav.ung.deltakelseopplyser.domene.register
+
+import no.nav.ung.deltakelseopplyser.integration.nom.api.NomApiService
+import no.nav.ung.deltakelseopplyser.integration.nom.api.domene.OrgEnhetMedPeriode
+import no.nav.ung.deltakelseopplyser.integration.nom.api.domene.RessursMedAlleTilknytninger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+@Service
+class DeltakelseVeilederEnhetService(
+    private val deltakelseVeilederEnhetRepository: DeltakelseVeilederEnhetRepository,
+    private val nomApiService: NomApiService,
+) {
+    private companion object {
+        private val logger = LoggerFactory.getLogger(DeltakelseVeilederEnhetService::class.java)
+    }
+
+    /**
+     * Henter alle koblinger for gitte deltakelse-IDer.
+     * Returnerer en map fra deltakelseId til enhetNavn.
+     */
+    fun hentEnhetNavnForDeltakelser(deltakelseIder: List<UUID>): Map<UUID, String> {
+        if (deltakelseIder.isEmpty()) return emptyMap()
+        return deltakelseVeilederEnhetRepository.findAllByDeltakelseIdIn(deltakelseIder)
+            .associate { it.deltakelseId to it.enhetNavn }
+    }
+
+    /**
+     * Henter enhet-kobling for en enkelt deltakelse. Returnerer null hvis ikke funnet.
+     */
+    fun hentEnhetKoblingForDeltakelse(deltakelseId: UUID): DeltakelseVeilederEnhetDAO? {
+        return deltakelseVeilederEnhetRepository.findByDeltakelseId(deltakelseId)
+    }
+
+    /**
+     * Prøver å resolve veilederens nåværende enhet fra NOM og lagre koblingen.
+     * Feiler stille (try-catch) slik at innmeldingen ikke blokkeres.
+     */
+    fun prøvLagreEnhetForDeltakelse(deltakelseId: UUID, navIdent: String) {
+        try {
+            val ressurser = nomApiService.hentResursserMedAlleTilknytninger(setOf(navIdent))
+            val ressurs = ressurser.firstOrNull()
+
+            if (ressurs == null) {
+                logger.warn("Kunne ikke lagre enhet-kobling for deltakelse $deltakelseId: Fant ingen NOM-ressurs for NAV-ident $navIdent")
+                return
+            }
+
+            val enhet = resolveGyldigEnhet(ressurs, LocalDate.now())
+            if (enhet == null) {
+                logger.warn("Kunne ikke lagre enhet-kobling for deltakelse $deltakelseId: Fant ingen gyldig enhet for NAV-ident $navIdent")
+                return
+            }
+
+            deltakelseVeilederEnhetRepository.save(
+                DeltakelseVeilederEnhetDAO(
+                    deltakelseId = deltakelseId,
+                    navIdent = navIdent,
+                    enhetId = enhet.id,
+                    enhetNavn = enhet.navn,
+                )
+            )
+            logger.info("Lagret enhet-kobling for deltakelse $deltakelseId: NAV-ident=$navIdent, enhet=${enhet.navn} (${enhet.id})")
+        } catch (e: Exception) {
+            logger.error("Feil ved lagring av enhet-kobling for deltakelse $deltakelseId, NAV-ident $navIdent. Fortsetter uten kobling.", e)
+        }
+    }
+
+    /**
+     * Oppdaterer (upsert) enhet-kobling for en spesifikk deltakelse.
+     * Brukes via diagnostikk-endepunktet for manuell korrigering.
+     */
+    fun oppdaterEnhetKobling(deltakelseId: UUID, navIdent: String, enhetId: String, enhetNavn: String): DeltakelseVeilederEnhetDAO {
+        val eksisterende = deltakelseVeilederEnhetRepository.findByDeltakelseId(deltakelseId)
+
+        return if (eksisterende != null) {
+            eksisterende.enhetId = enhetId
+            eksisterende.enhetNavn = enhetNavn
+            deltakelseVeilederEnhetRepository.save(eksisterende).also {
+                logger.info("Oppdatert enhet-kobling for deltakelse $deltakelseId: enhet=$enhetNavn ($enhetId)")
+            }
+        } else {
+            deltakelseVeilederEnhetRepository.save(
+                DeltakelseVeilederEnhetDAO(
+                    deltakelseId = deltakelseId,
+                    navIdent = navIdent,
+                    enhetId = enhetId,
+                    enhetNavn = enhetNavn,
+                )
+            ).also {
+                logger.info("Opprettet enhet-kobling for deltakelse $deltakelseId: NAV-ident=$navIdent, enhet=$enhetNavn ($enhetId)")
+            }
+        }
+    }
+
+    /**
+     * Backfill: Lagrer enhets-koblinger for en liste med deltakelser basert på NOM-data.
+     * Returnerer resultat med antall vellykkede/feilede koblinger.
+     */
+    fun backfillEnhetKoblinger(
+        deltakelser: List<BackfillInput>,
+        ressurserMedTilknytninger: List<RessursMedAlleTilknytninger>,
+    ): BackfillResultat {
+        val eksisterendeKoblinger = deltakelseVeilederEnhetRepository
+            .findAllByDeltakelseIdIn(deltakelser.map { it.deltakelseId })
+            .map { it.deltakelseId }
+            .toSet()
+
+        val ressursLookup = ressurserMedTilknytninger.associateBy { it.navIdent }
+        var antallOpprettet = 0
+        var antallHoppetOver = 0
+        val feiledeIdenter = mutableSetOf<String>()
+
+        deltakelser.forEach { input ->
+            if (input.deltakelseId in eksisterendeKoblinger) {
+                antallHoppetOver++
+                return@forEach
+            }
+
+            val ressurs = ressursLookup[input.navIdent]
+            if (ressurs == null) {
+                feiledeIdenter.add(input.navIdent)
+                return@forEach
+            }
+
+            // Bruk nærmeste tilknytning uten toleransegrense for historiske deltakelser
+            val enhet = resolveNærmesteEnhet(ressurs, input.opprettetDato)
+            if (enhet == null) {
+                feiledeIdenter.add(input.navIdent)
+                return@forEach
+            }
+
+            deltakelseVeilederEnhetRepository.save(
+                DeltakelseVeilederEnhetDAO(
+                    deltakelseId = input.deltakelseId,
+                    navIdent = input.navIdent,
+                    enhetId = enhet.id,
+                    enhetNavn = enhet.navn,
+                )
+            )
+            antallOpprettet++
+        }
+
+        logger.info("Backfill ferdig: $antallOpprettet opprettet, $antallHoppetOver hoppet over (eksisterte), ${feiledeIdenter.size} unike identer feilet: $feiledeIdenter")
+        return BackfillResultat(antallOpprettet, antallHoppetOver, feiledeIdenter)
+    }
+
+    /**
+     * Finner gyldig enhet for en veileder på en gitt dato.
+     * Eksakt match, deretter bakover/fremover-fallback med 90 dager.
+     */
+    private fun resolveGyldigEnhet(ressurs: RessursMedAlleTilknytninger, dato: LocalDate): OrgEnhetMedPeriode? {
+        val eksaktGyldig = ressurs.orgTilknytninger
+            .filter { it.erGyldigPåTidspunkt(dato) }
+            .map { it.orgEnhet }
+            .filter { it.erGyldigPåTidspunkt(dato) }
+            .firstOrNull()
+
+        if (eksaktGyldig != null) return eksaktGyldig
+
+        val toleranseDager = 90L
+        return ressurs.orgTilknytninger
+            .mapNotNull { tilknytning ->
+                val avstand = beregnAvstand(tilknytning.gyldigFom, tilknytning.gyldigTom, dato)
+                if (avstand <= toleranseDager) tilknytning.orgEnhet to avstand else null
+            }
+            .minByOrNull { it.second }
+            ?.first
+    }
+
+    /**
+     * Finner nærmeste tilknytning uten toleransegrense.
+     * Brukes for backfill av historiske deltakelser.
+     */
+    private fun resolveNærmesteEnhet(ressurs: RessursMedAlleTilknytninger, dato: LocalDate): OrgEnhetMedPeriode? {
+        if (ressurs.orgTilknytninger.isEmpty()) return null
+
+        val eksaktGyldig = ressurs.orgTilknytninger
+            .filter { it.erGyldigPåTidspunkt(dato) }
+            .map { it.orgEnhet }
+            .filter { it.erGyldigPåTidspunkt(dato) }
+            .firstOrNull()
+
+        if (eksaktGyldig != null) return eksaktGyldig
+
+        return ressurs.orgTilknytninger
+            .map { tilknytning -> tilknytning.orgEnhet to beregnAvstand(tilknytning.gyldigFom, tilknytning.gyldigTom, dato) }
+            .minByOrNull { it.second }
+            ?.first
+    }
+
+    /**
+     * Beregner den absolutte avstanden i dager mellom en tilknytningsperiode og en dato.
+     * Returnerer 0 hvis datoen er innenfor perioden.
+     */
+    private fun beregnAvstand(gyldigFom: LocalDate, gyldigTom: LocalDate?, dato: LocalDate): Long {
+        return when {
+            dato.isBefore(gyldigFom) -> ChronoUnit.DAYS.between(dato, gyldigFom)
+            gyldigTom != null && dato.isAfter(gyldigTom) -> ChronoUnit.DAYS.between(gyldigTom, dato)
+            else -> 0L
+        }
+    }
+
+    data class BackfillInput(
+        val deltakelseId: UUID,
+        val navIdent: String,
+        val opprettetDato: LocalDate,
+    )
+
+    data class BackfillResultat(
+        val antallOpprettet: Int,
+        val antallHoppetOver: Int,
+        val feiledeNavIdenter: Set<String>,
+    )
+}
+

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetService.kt
@@ -45,13 +45,24 @@ class DeltakelseVeilederEnhetService(
             val ressurs = ressurser.firstOrNull()
 
             if (ressurs == null) {
-                logger.warn("Kunne ikke lagre enhet-kobling for deltakelse $deltakelseId: Fant ingen NOM-ressurs for NAV-ident $navIdent")
+                logger.warn(
+                    "Kunne ikke lagre enhet-kobling for deltakelse {}: Fant ingen NOM-ressurs for NAV-ident {} (NOM returnerte {} ressurser)",
+                    deltakelseId, navIdent, ressurser.size
+                )
                 return
             }
 
-            val enhet = resolveGyldigEnhet(ressurs, LocalDate.now())
+            val dato = LocalDate.now()
+            val enhet = resolveGyldigEnhet(ressurs, dato)
             if (enhet == null) {
-                logger.warn("Kunne ikke lagre enhet-kobling for deltakelse $deltakelseId: Fant ingen gyldig enhet for NAV-ident $navIdent")
+                val tilknytninger = ressurs.orgTilknytninger.joinToString { t ->
+                    "${t.orgEnhet.navn} (${t.gyldigFom}–${t.gyldigTom ?: "løpende"})"
+                }
+                logger.warn(
+                    "Kunne ikke lagre enhet-kobling for deltakelse {}: Fant ingen gyldig enhet for NAV-ident {} på {} " +
+                            "(antallTilknytninger={}, tilknytninger=[{}])",
+                    deltakelseId, navIdent, dato, ressurs.orgTilknytninger.size, tilknytninger
+                )
                 return
             }
 
@@ -63,9 +74,15 @@ class DeltakelseVeilederEnhetService(
                     enhetNavn = enhet.navn,
                 )
             )
-            logger.info("Lagret enhet-kobling for deltakelse $deltakelseId: NAV-ident=$navIdent, enhet=${enhet.navn} (${enhet.id})")
+            logger.info(
+                "Lagret enhet-kobling for deltakelse {}: NAV-ident={}, enhet={} ({})",
+                deltakelseId, navIdent, enhet.navn, enhet.id
+            )
         } catch (e: Exception) {
-            logger.error("Feil ved lagring av enhet-kobling for deltakelse $deltakelseId, NAV-ident $navIdent. Fortsetter uten kobling.", e)
+            logger.error(
+                "Feil ved lagring av enhet-kobling for deltakelse {}, NAV-ident {}. Fortsetter uten kobling.",
+                deltakelseId, navIdent, e
+            )
         }
     }
 
@@ -112,7 +129,8 @@ class DeltakelseVeilederEnhetService(
         val ressursLookup = ressurserMedTilknytninger.associateBy { it.navIdent }
         var antallOpprettet = 0
         var antallHoppetOver = 0
-        val feiledeIdenter = mutableSetOf<String>()
+        val identerUtenRessurs = mutableSetOf<String>()
+        val identerUtenGyldigEnhet = mutableSetOf<String>()
 
         deltakelser.forEach { input ->
             if (input.deltakelseId in eksisterendeKoblinger) {
@@ -122,14 +140,18 @@ class DeltakelseVeilederEnhetService(
 
             val ressurs = ressursLookup[input.navIdent]
             if (ressurs == null) {
-                feiledeIdenter.add(input.navIdent)
+                identerUtenRessurs.add(input.navIdent)
                 return@forEach
             }
 
             // Bruk nærmeste tilknytning uten toleransegrense for historiske deltakelser
             val enhet = resolveNærmesteEnhet(ressurs, input.opprettetDato)
             if (enhet == null) {
-                feiledeIdenter.add(input.navIdent)
+                identerUtenGyldigEnhet.add(input.navIdent)
+                logger.debug(
+                    "Backfill: Ingen gyldig enhet for NAV-ident {} på {} (deltakelseId={}, antallTilknytninger={})",
+                    input.navIdent, input.opprettetDato, input.deltakelseId, ressurs.orgTilknytninger.size
+                )
                 return@forEach
             }
 
@@ -144,7 +166,13 @@ class DeltakelseVeilederEnhetService(
             antallOpprettet++
         }
 
-        logger.info("Backfill ferdig: $antallOpprettet opprettet, $antallHoppetOver hoppet over (eksisterte), ${feiledeIdenter.size} unike identer feilet: $feiledeIdenter")
+        val feiledeIdenter = identerUtenRessurs + identerUtenGyldigEnhet
+        logger.info(
+            "Backfill ferdig: {} opprettet, {} hoppet over (eksisterte), {} feilet " +
+                    "(ingen NOM-ressurs: {}, ingen gyldig enhet: {})",
+            antallOpprettet, antallHoppetOver, feiledeIdenter.size,
+            identerUtenRessurs, identerUtenGyldigEnhet
+        )
         return BackfillResultat(antallOpprettet, antallHoppetOver, feiledeIdenter)
     }
 
@@ -216,4 +244,3 @@ class DeltakelseVeilederEnhetService(
         val feiledeNavIdenter: Set<String>,
     )
 }
-

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -9,6 +9,7 @@ import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerDAO
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerPersonalia
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService
 import no.nav.ung.deltakelseopplyser.domene.deltaker.DeltakerService.Companion.mapToDTO
+import no.nav.ung.deltakelseopplyser.historikk.AuditorAwareImpl.Companion.VEILEDER_SUFFIX
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngBrukerdialogService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngSakService
@@ -41,6 +42,7 @@ class UngdomsprogramregisterService(
     private val ungSakService: UngSakService,
     private val pdlService: PdlService,
     private val ungBrukerdialogService: UngBrukerdialogService,
+    private val deltakelseVeilederEnhetService: DeltakelseVeilederEnhetService,
     @Value("\${SLETT_SOKT_DELTAKELSE_ENABLED}") private val slettSoktDeltakelseEnabled: Boolean
 ) {
     companion object {
@@ -76,6 +78,21 @@ class UngdomsprogramregisterService(
 
         val deltakelseDAO = deltakelseDTO.mapToDAO(deltakerDAO)
         val ungdomsprogramDAO = deltakelseRepository.saveAndFlush(deltakelseDAO)
+
+        // Lagre veileder → enhet kobling for statistikk (point-in-time snapshot).
+        // Feiler stille slik at innmeldingen ikke blokkeres ved NOM-problemer.
+        try {
+            val navIdent = ungdomsprogramDAO.opprettetAv
+                .removeSuffix(VEILEDER_SUFFIX).trim()
+            if (navIdent != "system") {
+                deltakelseVeilederEnhetService.prøvLagreEnhetForDeltakelse(
+                    deltakelseId = ungdomsprogramDAO.id,
+                    navIdent = navIdent
+                )
+            }
+        } catch (e: Exception) {
+            logger.warn("Kunne ikke lagre enhet-kobling for deltakelse ${ungdomsprogramDAO.id}. Fortsetter.", e)
+        }
 
         val oppgaveReferanse = UUID.randomUUID()
         pdlService.hentAktørIder(deltakerDAO.deltakerIdent).filter { it.historisk == false }.firstOrNull()?.let {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/drift/DiagnostikkDriftController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/drift/DiagnostikkDriftController.kt
@@ -18,10 +18,13 @@ import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendR
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendStatus
 import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseDAO
 import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseVeilederEnhetService
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService.Companion.mapToDTO
 import no.nav.ung.deltakelseopplyser.domene.register.historikk.DeltakelseHistorikk
 import no.nav.ung.deltakelseopplyser.domene.register.historikk.DeltakelseHistorikkService
+import no.nav.ung.deltakelseopplyser.historikk.AuditorAwareImpl.Companion.VEILEDER_SUFFIX
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
+import no.nav.ung.deltakelseopplyser.integration.nom.api.NomApiService
 import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseDTO
 import no.nav.ung.deltakelseopplyser.statistikk.deltakelse.DeltakelseStatistikkService
 import org.springframework.http.HttpStatus
@@ -29,12 +32,14 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.util.*
 
@@ -55,6 +60,8 @@ class DiagnostikkDriftController(
     private val deltakelseStatistikkService: DeltakelseStatistikkService,
     private val deltakerRepository: DeltakerRepository,
     private val microfrontendRepository: MicrofrontendRepository,
+    private val deltakelseVeilederEnhetService: DeltakelseVeilederEnhetService,
+    private val nomApiService: NomApiService,
 ) {
     @PostMapping(
         "/hent/deltakelse/{deltakelseId}",
@@ -170,5 +177,105 @@ class DiagnostikkDriftController(
         val status: MicrofrontendStatus,
         val opprettet: ZonedDateTime?,
         val endret: LocalDateTime?,
+    )
+
+    // === Koblingstabellen deltakelse → veileder → enhet ===
+
+    @PostMapping("/backfill/deltakelse-veileder-enhet", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(summary = "Backfill koblingstabellen deltakelse→veileder→enhet basert på NOM-data for alle deltakelser som mangler kobling")
+    @ResponseStatus(HttpStatus.OK)
+    fun backfillDeltakelseVeilederEnhet(): Map<String, Any> {
+        tilgangskontrollService.krevDriftsTilgang(BeskyttetRessursActionAttributt.CREATE)
+
+        val alleDeltakelser = deltakelseRepository.findAll()
+
+        val backfillInputs = alleDeltakelser.map { deltakelse ->
+            DeltakelseVeilederEnhetService.BackfillInput(
+                deltakelseId = deltakelse.id,
+                navIdent = deltakelse.opprettetAv.removeSuffix(VEILEDER_SUFFIX).trim(),
+                opprettetDato = deltakelse.opprettetTidspunkt.atZone(ZoneOffset.UTC).toLocalDate()
+            )
+        }
+
+        val navIdenter = backfillInputs.map { it.navIdent }.toSet()
+        val ressurser = nomApiService.hentResursserMedAlleTilknytninger(navIdenter)
+
+        val resultat = deltakelseVeilederEnhetService.backfillEnhetKoblinger(backfillInputs, ressurser)
+
+        return mapOf(
+            "totalDeltakelser" to alleDeltakelser.size,
+            "antallOpprettet" to resultat.antallOpprettet,
+            "antallHoppetOver" to resultat.antallHoppetOver,
+            "feiledeNavIdenter" to resultat.feiledeNavIdenter,
+        )
+    }
+
+    @PutMapping(
+        "/deltakelse-veileder-enhet/{deltakelseId}",
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @Operation(summary = "Opprett eller oppdater enhet-kobling for en spesifikk deltakelse. Brukes for manuell korrigering.")
+    @ResponseStatus(HttpStatus.OK)
+    fun oppdaterDeltakelseVeilederEnhet(
+        @PathVariable deltakelseId: UUID,
+        @RequestBody request: OppdaterDeltakelseVeilederEnhetRequest,
+    ): DeltakelseVeilederEnhetDto {
+        tilgangskontrollService.krevDriftsTilgang(BeskyttetRessursActionAttributt.UPDATE)
+
+        val deltakelse = deltakelseRepository.findById(deltakelseId)
+            .orElseThrow { IllegalArgumentException("Fant ikke deltakelse med id $deltakelseId") }
+
+        val navIdent = request.navIdent
+            ?: deltakelse.opprettetAv.removeSuffix(VEILEDER_SUFFIX).trim()
+
+        val dao = deltakelseVeilederEnhetService.oppdaterEnhetKobling(
+            deltakelseId = deltakelseId,
+            navIdent = navIdent,
+            enhetId = request.enhetId,
+            enhetNavn = request.enhetNavn,
+        )
+
+        return DeltakelseVeilederEnhetDto(
+            deltakelseId = dao.deltakelseId,
+            navIdent = dao.navIdent,
+            enhetId = dao.enhetId,
+            enhetNavn = dao.enhetNavn,
+        )
+    }
+
+    @GetMapping(
+        "/deltakelse-veileder-enhet/{deltakelseId}",
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @Operation(summary = "Hent enhet-kobling for en spesifikk deltakelse")
+    @ResponseStatus(HttpStatus.OK)
+    fun hentDeltakelseVeilederEnhet(
+        @PathVariable deltakelseId: UUID,
+    ): DeltakelseVeilederEnhetDto? {
+        tilgangskontrollService.krevDriftsTilgang(BeskyttetRessursActionAttributt.READ)
+
+        val dao = deltakelseVeilederEnhetService.hentEnhetKoblingForDeltakelse(deltakelseId)
+            ?: return null
+
+        return DeltakelseVeilederEnhetDto(
+            deltakelseId = dao.deltakelseId,
+            navIdent = dao.navIdent,
+            enhetId = dao.enhetId,
+            enhetNavn = dao.enhetNavn,
+        )
+    }
+
+    data class OppdaterDeltakelseVeilederEnhetRequest(
+        val enhetId: String,
+        val enhetNavn: String,
+        val navIdent: String? = null,
+    )
+
+    data class DeltakelseVeilederEnhetDto(
+        val deltakelseId: UUID,
+        val navIdent: String,
+        val enhetId: String,
+        val enhetNavn: String,
     )
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
@@ -119,10 +119,13 @@ class DeltakelsePerEnhetStatistikkTeller {
     /**
      * Finner gyldige enheter for en veileder på en gitt dato.
      *
-     * Bruker to strategier:
+     * Bruker tre strategier i prioritert rekkefølge:
      * 1. **Eksakt match**: Både tilknytning og orgEnhet må være gyldig på datoen.
-     * 2. **Fallback (90 dager)**: Hvis ingen eksakt match, brukes den sist utløpte tilknytningen
-     *    som sluttet innen 90 dager før datoen. Dette dekker gap i NOM ved enhetsbytte.
+     * 2. **Bakover-fallback (90 dager)**: Bruker den sist utløpte tilknytningen som sluttet
+     *    innen 90 dager før datoen. Dekker gap i NOM ved enhetsbytte.
+     * 3. **Fremover-fallback (90 dager)**: Bruker den tidligste tilknytningen som starter
+     *    innen 90 dager etter datoen. Dekker tilfeller der NOM-registreringen kom etter
+     *    at veilederen allerede jobbet ved enheten og opprettet deltakelser.
      */
     private fun finnGyldigeEnheter(
         ressurs: RessursMedAlleTilknytninger,
@@ -140,9 +143,8 @@ class DeltakelsePerEnhetStatistikkTeller {
             return eksaktGyldigeEnheter
         }
 
-        // Strategi 2 (fallback): Finn siste gyldige enhet innen toleranseperiode.
-        // Toleranseperioden overbrygger korte gap i NOM-data som oppstår ved enhetsbytte,
-        // der den gamle tilknytningen har utløpt men den nye ikke er registrert ennå.
+        // Strategi 2 (bakover-fallback): Finn siste gyldige enhet innen toleranseperiode.
+        // Dekker gap der den gamle tilknytningen har utløpt men den nye ikke er registrert ennå.
         val toleranseDager = 90L
 
         val sisteGyldigeEnhet = ressurs.orgTilknytninger
@@ -161,14 +163,38 @@ class DeltakelsePerEnhetStatistikkTeller {
 
         if (sisteGyldigeEnhet.isNotEmpty()) {
             logger.info(
-                "Bruker fallback: Fant ingen gyldig enhet for NAV-ident ${ressurs.navIdent} på $opprettetDato, " +
+                "Bruker bakover-fallback: Fant ingen gyldig enhet for NAV-ident ${ressurs.navIdent} på $opprettetDato, " +
                         "bruker siste gyldige enhet: ${sisteGyldigeEnhet.first().navn} " +
                         "(gyldigTom: ${ressurs.orgTilknytninger.first { it.orgEnhet.id == sisteGyldigeEnhet.first().id }.gyldigTom})"
             )
             return sisteGyldigeEnhet
         }
 
-        logger.warn("Fant ingen gyldig enhet for NAV-ident ${ressurs.navIdent} på tidspunkt $opprettetDato, heller ikke i fallback. Prøv å øke toleranseDager.")
+        // Strategi 3 (fremover-fallback): Finn den tidligste fremtidige tilknytningen innen toleranseperiode.
+        // Dekker tilfeller der veilederen allerede jobbet ved enheten og opprettet deltakelser,
+        // men NOM-registreringen kom først etterpå.
+        val nesteGyldigeEnhet = ressurs.orgTilknytninger
+            .filter { tilknytning ->
+                // Tilknytningen må starte etter opprettelsesdatoen (den har ikke startet ennå)
+                tilknytning.gyldigFom.isAfter(opprettetDato) &&
+                        // Startdatoen må ikke ligge mer enn 90 dager etter opprettelsesdatoen
+                        !tilknytning.gyldigFom.isAfter(opprettetDato.plusDays(toleranseDager))
+            }
+            // Velg den som starter først (mest sannsynlig riktig enhet)
+            .sortedBy { it.gyldigFom }
+            .take(1)
+            .map { it.orgEnhet }
+
+        if (nesteGyldigeEnhet.isNotEmpty()) {
+            logger.info(
+                "Bruker fremover-fallback: Fant ingen gyldig enhet for NAV-ident ${ressurs.navIdent} på $opprettetDato, " +
+                        "bruker neste registrerte enhet: ${nesteGyldigeEnhet.first().navn} " +
+                        "(gyldigFom: ${ressurs.orgTilknytninger.first { it.orgEnhet.id == nesteGyldigeEnhet.first().id }.gyldigFom})"
+            )
+            return nesteGyldigeEnhet
+        }
+
+        logger.warn("Fant ingen gyldig enhet for NAV-ident ${ressurs.navIdent} på tidspunkt $opprettetDato, heller ikke i fallback (bakover/fremover $toleranseDager dager).")
         return emptyList()
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
@@ -5,6 +5,7 @@ import no.nav.ung.deltakelseopplyser.integration.nom.api.domene.OrgEnhetMedPerio
 import no.nav.ung.deltakelseopplyser.integration.nom.api.domene.RessursMedAlleTilknytninger
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import java.util.*
 
 /**
@@ -119,13 +120,15 @@ class DeltakelsePerEnhetStatistikkTeller {
     /**
      * Finner gyldige enheter for en veileder på en gitt dato.
      *
-     * Bruker tre strategier i prioritert rekkefølge:
+     * Bruker fire strategier i prioritert rekkefølge:
      * 1. **Eksakt match**: Både tilknytning og orgEnhet må være gyldig på datoen.
      * 2. **Bakover-fallback (90 dager)**: Bruker den sist utløpte tilknytningen som sluttet
      *    innen 90 dager før datoen. Dekker gap i NOM ved enhetsbytte.
      * 3. **Fremover-fallback (90 dager)**: Bruker den tidligste tilknytningen som starter
      *    innen 90 dager etter datoen. Dekker tilfeller der NOM-registreringen kom etter
      *    at veilederen allerede jobbet ved enheten og opprettet deltakelser.
+     * 4. **Nærmeste tilknytning (ubegrenset)**: Velger tilknytningen med korteste absolutte
+     *    avstand til datoen, uten toleransegrense. Siste utvei for historiske deltakelser.
      */
     private fun finnGyldigeEnheter(
         ressurs: RessursMedAlleTilknytninger,
@@ -194,7 +197,32 @@ class DeltakelsePerEnhetStatistikkTeller {
             return nesteGyldigeEnhet
         }
 
-        logger.warn("Fant ingen gyldig enhet for NAV-ident ${ressurs.navIdent} på tidspunkt $opprettetDato, heller ikke i fallback (bakover/fremover $toleranseDager dager).")
+        // Strategi 4 (nærmeste tilknytning uten toleransegrense): Siste utvei for historiske deltakelser
+        // der strategi 1–3 ikke matcher. Velger tilknytningen med korteste absolutte avstand
+        // til opprettelsesdatoen. Bedre enn å miste deltakelsen til sikkerhetsnett.
+        val nærmesteTilknytning = ressurs.orgTilknytninger
+            .map { tilknytning ->
+                val avstand = when {
+                    opprettetDato.isBefore(tilknytning.gyldigFom) ->
+                        ChronoUnit.DAYS.between(opprettetDato, tilknytning.gyldigFom)
+                    tilknytning.gyldigTom != null && opprettetDato.isAfter(tilknytning.gyldigTom) ->
+                        ChronoUnit.DAYS.between(tilknytning.gyldigTom, opprettetDato)
+                    else -> 0L
+                }
+                tilknytning to avstand
+            }
+            .minByOrNull { it.second }
+
+        if (nærmesteTilknytning != null) {
+            logger.warn(
+                "Bruker nærmeste-tilknytning-fallback (ubegrenset): NAV-ident ${ressurs.navIdent} " +
+                        "på $opprettetDato, bruker ${nærmesteTilknytning.first.orgEnhet.navn} " +
+                        "(avstand: ${nærmesteTilknytning.second} dager)"
+            )
+            return listOf(nærmesteTilknytning.first.orgEnhet)
+        }
+
+        logger.warn("Fant ingen enhet for NAV-ident ${ressurs.navIdent} på $opprettetDato — ingen tilknytninger i NOM.")
         return emptyList()
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
@@ -32,7 +32,7 @@ data class DeltakelsePerEnhetResultat(
  * Tellingen fungerer slik:
  * 1. Hver deltakelse mappes til enheten veilederen tilhørte på opprettelsestidspunktet (via NOM).
  * 2. Hvis veilederen hadde flere gyldige enheter på datoen, velges den mest populære (flest veiledere totalt).
- * 3. Hvis ingen enhet er gyldig på eksakt dato, brukes en fallback med 90-dagers toleranse.
+ * 3. Hvis ingen enhet er gyldig på eksakt dato, brukes nærmeste tilknytning som fallback.
  * 4. Deltakelser som ikke kan mappes til noen enhet, telles under [ENHET_SIKKERHETSNETT]
  *    slik at totalsummen alltid stemmer med antall input-deltakelser.
  */
@@ -88,7 +88,7 @@ class DeltakelsePerEnhetStatistikkTeller {
 
         // Veilederen finnes ikke i NOM — kan skyldes at de har sluttet eller ikke er registrert
         if (ressurs == null) {
-            logger.warn("Fant ingen ressurs for NAV-ident $navIdent")
+            logger.warn("Fant ingen NOM-ressurs for NAV-ident {} (deltakelseId={})", navIdent, deltakelse.id)
             return null
         }
 
@@ -98,7 +98,10 @@ class DeltakelsePerEnhetStatistikkTeller {
         return when {
             // Ingen gyldige enheter funnet, heller ikke via fallback
             gyldigeEnheter.isEmpty() -> {
-                logger.warn("Fant ingen gyldig enhet for NAV-ident $navIdent på tidspunkt ${deltakelse.opprettetDato}")
+                logger.warn(
+                    "Fant ingen gyldig enhet for NAV-ident {} på {} (deltakelseId={}, antallTilknytninger={})",
+                    navIdent, deltakelse.opprettetDato, deltakelse.id, ressurs.orgTilknytninger.size
+                )
                 null
             }
             // Nøyaktig én gyldig enhet — bruk den direkte
@@ -120,15 +123,11 @@ class DeltakelsePerEnhetStatistikkTeller {
     /**
      * Finner gyldige enheter for en veileder på en gitt dato.
      *
-     * Bruker fire strategier i prioritert rekkefølge:
+     * Bruker to strategier i prioritert rekkefølge:
      * 1. **Eksakt match**: Både tilknytning og orgEnhet må være gyldig på datoen.
-     * 2. **Bakover-fallback (90 dager)**: Bruker den sist utløpte tilknytningen som sluttet
-     *    innen 90 dager før datoen. Dekker gap i NOM ved enhetsbytte.
-     * 3. **Fremover-fallback (90 dager)**: Bruker den tidligste tilknytningen som starter
-     *    innen 90 dager etter datoen. Dekker tilfeller der NOM-registreringen kom etter
-     *    at veilederen allerede jobbet ved enheten og opprettet deltakelser.
-     * 4. **Nærmeste tilknytning (ubegrenset)**: Velger tilknytningen med korteste absolutte
-     *    avstand til datoen, uten toleransegrense. Siste utvei for historiske deltakelser.
+     * 2. **Nærmeste tilknytning**: Velger tilknytningen med korteste absolutte avstand
+     *    til datoen. Dekker gap i NOM ved enhetsbytte, sen NOM-registrering, og
+     *    historiske deltakelser.
      */
     private fun finnGyldigeEnheter(
         ressurs: RessursMedAlleTilknytninger,
@@ -146,61 +145,9 @@ class DeltakelsePerEnhetStatistikkTeller {
             return eksaktGyldigeEnheter
         }
 
-        // Strategi 2 (bakover-fallback): Finn siste gyldige enhet innen toleranseperiode.
-        // Dekker gap der den gamle tilknytningen har utløpt men den nye ikke er registrert ennå.
-        val toleranseDager = 90L
-
-        val sisteGyldigeEnhet = ressurs.orgTilknytninger
-            .filter { tilknytning ->
-                // Tilknytningen må ha startet før (eller på) opprettelsesdatoen
-                !tilknytning.gyldigFom.isAfter(opprettetDato) &&
-                        // Tilknytningen må ha en sluttdato (dvs. den har utløpt)
-                        tilknytning.gyldigTom != null &&
-                        // Sluttdatoen må ikke ligge mer enn 90 dager før opprettelsesdatoen
-                        !tilknytning.gyldigTom.isBefore(opprettetDato.minusDays(toleranseDager))
-            }
-            // Velg den som utløp sist (mest sannsynlig riktig enhet)
-            .sortedByDescending { it.gyldigTom }
-            .take(1)
-            .map { it.orgEnhet }
-
-        if (sisteGyldigeEnhet.isNotEmpty()) {
-            logger.info(
-                "Bruker bakover-fallback: Fant ingen gyldig enhet for NAV-ident ${ressurs.navIdent} på $opprettetDato, " +
-                        "bruker siste gyldige enhet: ${sisteGyldigeEnhet.first().navn} " +
-                        "(gyldigTom: ${ressurs.orgTilknytninger.first { it.orgEnhet.id == sisteGyldigeEnhet.first().id }.gyldigTom})"
-            )
-            return sisteGyldigeEnhet
-        }
-
-        // Strategi 3 (fremover-fallback): Finn den tidligste fremtidige tilknytningen innen toleranseperiode.
-        // Dekker tilfeller der veilederen allerede jobbet ved enheten og opprettet deltakelser,
-        // men NOM-registreringen kom først etterpå.
-        val nesteGyldigeEnhet = ressurs.orgTilknytninger
-            .filter { tilknytning ->
-                // Tilknytningen må starte etter opprettelsesdatoen (den har ikke startet ennå)
-                tilknytning.gyldigFom.isAfter(opprettetDato) &&
-                        // Startdatoen må ikke ligge mer enn 90 dager etter opprettelsesdatoen
-                        !tilknytning.gyldigFom.isAfter(opprettetDato.plusDays(toleranseDager))
-            }
-            // Velg den som starter først (mest sannsynlig riktig enhet)
-            .sortedBy { it.gyldigFom }
-            .take(1)
-            .map { it.orgEnhet }
-
-        if (nesteGyldigeEnhet.isNotEmpty()) {
-            logger.info(
-                "Bruker fremover-fallback: Fant ingen gyldig enhet for NAV-ident ${ressurs.navIdent} på $opprettetDato, " +
-                        "bruker neste registrerte enhet: ${nesteGyldigeEnhet.first().navn} " +
-                        "(gyldigFom: ${ressurs.orgTilknytninger.first { it.orgEnhet.id == nesteGyldigeEnhet.first().id }.gyldigFom})"
-            )
-            return nesteGyldigeEnhet
-        }
-
-        // Strategi 4 (nærmeste tilknytning uten toleransegrense): Siste utvei for historiske deltakelser
-        // der strategi 1–3 ikke matcher. Velger tilknytningen med korteste absolutte avstand
-        // til opprettelsesdatoen. Bedre enn å miste deltakelsen til sikkerhetsnett.
-        val nærmesteTilknytning = ressurs.orgTilknytninger
+        // Strategi 2: Nærmeste tilknytning — velg den med korteste absolutte avstand til datoen.
+        // Dekker gap ved enhetsbytte, sen NOM-registrering, og historiske deltakelser.
+        val tilknytningerMedAvstand = ressurs.orgTilknytninger
             .map { tilknytning ->
                 val avstand = when {
                     opprettetDato.isBefore(tilknytning.gyldigFom) ->
@@ -211,18 +158,26 @@ class DeltakelsePerEnhetStatistikkTeller {
                 }
                 tilknytning to avstand
             }
-            .minByOrNull { it.second }
+            .sortedBy { it.second }
+
+        val nærmesteTilknytning = tilknytningerMedAvstand.firstOrNull()
 
         if (nærmesteTilknytning != null) {
+            val kandidater = tilknytningerMedAvstand.joinToString { (tilknytning, avstand) ->
+                "${tilknytning.orgEnhet.navn} (${tilknytning.gyldigFom}–${tilknytning.gyldigTom ?: "løpende"}, avstand: $avstand dager)"
+            }
             logger.warn(
-                "Bruker nærmeste-tilknytning-fallback (ubegrenset): NAV-ident ${ressurs.navIdent} " +
-                        "på $opprettetDato, bruker ${nærmesteTilknytning.first.orgEnhet.navn} " +
-                        "(avstand: ${nærmesteTilknytning.second} dager)"
+                "Nærmeste-tilknytning-fallback: NAV-ident {} på {} → {} (avstand: {} dager). Kandidater: [{}]",
+                ressurs.navIdent, opprettetDato, nærmesteTilknytning.first.orgEnhet.navn,
+                nærmesteTilknytning.second, kandidater
             )
             return listOf(nærmesteTilknytning.first.orgEnhet)
         }
 
-        logger.warn("Fant ingen enhet for NAV-ident ${ressurs.navIdent} på $opprettetDato — ingen tilknytninger i NOM.")
+        logger.warn(
+            "Fant ingen enhet for NAV-ident {} på {} — ingen tilknytninger i NOM.",
+            ressurs.navIdent, opprettetDato
+        )
         return emptyList()
     }
 
@@ -275,8 +230,8 @@ class DeltakelsePerEnhetStatistikkTeller {
         }
 
         logger.warn(
-            "NAV-ident hadde ${gyldigeEnheter.size} enheter på tidspunkt $opprettetDato [$enhetInfo], " +
-                    "valgte den mest populære: ${valgtEnhet.id}-${valgtEnhet.navn}"
+            "NAV-ident hadde {} enheter på tidspunkt {} [{}], valgte den mest populære: {}-{}",
+            gyldigeEnheter.size, opprettetDato, enhetInfo, valgtEnhet.id, valgtEnhet.navn
         )
     }
 
@@ -293,14 +248,16 @@ class DeltakelsePerEnhetStatistikkTeller {
             .toSet()
             .size
 
-        logger.info("Fant $antallUnikeNavIdenter unike NAV-identer fra ${deltakelser.size} deltakelser")
+        logger.info("Fant {} unike NAV-identer fra {} deltakelser", antallUnikeNavIdenter, deltakelser.size)
 
         if (deltakelserUtenEnhet.isNotEmpty()) {
             // Logg hvilke veiledere som ikke kunne mappes — indikerer datakvalitetsproblemer i NOM
             val berørteNavIdenter = deltakelserUtenEnhet.map { it.navIdent() }.toSet()
+            val berørteDeltakelseIder = deltakelserUtenEnhet.map { it.id }
             logger.warn(
-                "${deltakelserUtenEnhet.size} deltakelser kunne ikke mappes til en enhet og er telt under '$ENHET_SIKKERHETSNETT'. " +
-                        "Berørte NAV-identer: $berørteNavIdenter"
+                "{} deltakelser kunne ikke mappes til en enhet og er telt under '{}'. " +
+                        "Berørte NAV-identer: {}, deltakelseIder: {}",
+                deltakelserUtenEnhet.size, ENHET_SIKKERHETSNETT, berørteNavIdenter, berørteDeltakelseIder
             )
         }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkService.kt
@@ -2,6 +2,7 @@ package no.nav.ung.deltakelseopplyser.statistikk.deltakelse
 
 import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseDAO
 import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseVeilederEnhetService
 import no.nav.ung.deltakelseopplyser.historikk.AuditorAwareImpl.Companion.VEILEDER_SUFFIX
 import no.nav.ung.deltakelseopplyser.integration.nom.api.NomApiService
 import no.nav.ung.deltakelseopplyser.integration.nom.api.domene.RessursMedAlleTilknytninger
@@ -14,6 +15,7 @@ import java.time.ZonedDateTime
 class DeltakelseStatistikkService(
     private val deltakelseRepository: DeltakelseRepository,
     private val nomApiService: NomApiService,
+    private val deltakelseVeilederEnhetService: DeltakelseVeilederEnhetService,
     private val deltakelsePerEnhetStatistikkTeller: DeltakelsePerEnhetStatistikkTeller = DeltakelsePerEnhetStatistikkTeller()
 ) {
     private companion object {
@@ -26,7 +28,6 @@ class DeltakelseStatistikkService(
         val alleDeltakelser: List<DeltakelseDAO> = deltakelseRepository.findAll()
         logger.info("Henter enheter for {} deltakelser", alleDeltakelser.size)
 
-        // Konverter til input-format for beregner
         val deltakelseInputs = alleDeltakelser.map { deltakelse ->
             DeltakelseInput(
                 id = deltakelse.id,
@@ -35,29 +36,67 @@ class DeltakelseStatistikkService(
             )
         }
 
-        // Hent alle unike navIdenter fra deltakelsene
-        val navIdenter = deltakelseInputs
-            .map { it.opprettetAv.replace(VEILEDER_SUFFIX, "").trim() }
-            .toSet()
+        // Primærkilde: koblingstabellen (point-in-time snapshot av veileder→enhet)
+        val enhetKoblinger = deltakelseVeilederEnhetService
+            .hentEnhetNavnForDeltakelser(deltakelseInputs.map { it.id })
 
-        logger.info("Fant {} unike NAV-identer", navIdenter.size)
+        val (medKobling, utenKobling) = deltakelseInputs.partition { it.id in enhetKoblinger }
 
-        // Hent alle tilknytninger fra NOM API (ufiltrert med periodeinformasjon)
-        // Vi henter ufiltrerte data slik at periodefiltrering kan skje i beregner og testes
-        val ressurserMedAlleTilknytninger: List<RessursMedAlleTilknytninger> = nomApiService.hentResursserMedAlleTilknytninger(navIdenter)
-
-        val deltakelsePerEnhetResultat = deltakelsePerEnhetStatistikkTeller.tellAntallDeltakelserPerEnhet(
-            deltakelser = deltakelseInputs,
-            ressurserMedTilknytninger = ressurserMedAlleTilknytninger
+        logger.info(
+            "Koblingstabellen dekker ${medKobling.size} av ${deltakelseInputs.size} deltakelser. " +
+                    "${utenKobling.size} krever NOM-oppslag."
         )
 
-        // Konverter til statistikk-records
-        val statistikkRecords = deltakelsePerEnhetResultat.deltakelserPerEnhet.map { (enhetsNavn, antallDeltakelser) ->
+        // Deltakelser med kobling → bruk enhetNavn direkte
+        val deltakelserPerEnhetFraKobling: Map<String, Int> = medKobling
+            .map { enhetKoblinger[it.id]!! }
+            .groupingBy { it }
+            .eachCount()
+
+        // Deltakelser uten kobling → fallback til NOM-basert logikk
+        var deltakelserPerEnhetFraNom: Map<String, Int> = emptyMap()
+        var nomDiagnostikk: Map<Any, Any?> = emptyMap()
+
+        if (utenKobling.isNotEmpty()) {
+            val navIdenter = utenKobling
+                .map { it.opprettetAv.replace(VEILEDER_SUFFIX, "").trim() }
+                .toSet()
+
+            logger.info("Henter NOM-data for {} unike NAV-identer (deltakelser uten kobling)", navIdenter.size)
+            val ressurserMedAlleTilknytninger: List<RessursMedAlleTilknytninger> =
+                nomApiService.hentResursserMedAlleTilknytninger(navIdenter)
+
+            val nomResultat = deltakelsePerEnhetStatistikkTeller.tellAntallDeltakelserPerEnhet(
+                deltakelser = utenKobling,
+                ressurserMedTilknytninger = ressurserMedAlleTilknytninger
+            )
+            deltakelserPerEnhetFraNom = nomResultat.deltakelserPerEnhet
+            nomDiagnostikk = nomResultat.diagnostikk
+        }
+
+        // Slå sammen resultatene fra kobling og NOM
+        val samletDeltakelserPerEnhet = mutableMapOf<String, Int>()
+        deltakelserPerEnhetFraKobling.forEach { (enhet, antall) ->
+            samletDeltakelserPerEnhet.merge(enhet, antall, Int::plus)
+        }
+        deltakelserPerEnhetFraNom.forEach { (enhet, antall) ->
+            samletDeltakelserPerEnhet.merge(enhet, antall, Int::plus)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val diagnostikk = mapOf<Any, Any?>(
+            "antallMedKobling" to medKobling.size,
+            "antallUtenKobling" to utenKobling.size,
+            "totalAntallDeltakelser" to deltakelseInputs.size,
+            "nomDiagnostikk" to nomDiagnostikk,
+        )
+
+        val statistikkRecords = samletDeltakelserPerEnhet.map { (enhetsNavn, antallDeltakelser) ->
             AntallDeltakelsePerEnhetStatistikkRecord(
                 kontor = enhetsNavn,
                 antallDeltakelser = antallDeltakelser,
                 opprettetTidspunkt = kjøringstidspunkt,
-                diagnostikk = deltakelsePerEnhetResultat.diagnostikk
+                diagnostikk = diagnostikk
             )
         }
 
@@ -73,9 +112,9 @@ class DeltakelseStatistikkService(
     ) {
         val totalAntallDeltakelserStatistikk = statistikkRecords.sumOf { it.antallDeltakelser }
         if (kastFeilVedInkonsekventTelling && totalAntallDeltakelserStatistikk != alleDeltakelser.size) {
-            throw IllegalStateException("Inkonsekvent telling: Total antall deltakelser i statistikk (${totalAntallDeltakelserStatistikk}) stemmer ikke overens med totalt antall deltakelser (${alleDeltakelser.size})")
+            throw IllegalStateException("Inkonsekvent telling: Total antall deltakelser i statistikk ($totalAntallDeltakelserStatistikk) stemmer ikke overens med totalt antall deltakelser (${alleDeltakelser.size})")
         } else {
-            logger.info("Verifisert at total antall deltakelser i statistikk (${totalAntallDeltakelserStatistikk}) stemmer overens med totalt antall deltakelser for enhetene (${alleDeltakelser.size})")
+            logger.info("Verifisert at total antall deltakelser i statistikk ($totalAntallDeltakelserStatistikk) stemmer overens med totalt antall deltakelser for enhetene (${alleDeltakelser.size})")
         }
     }
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkService.kt
@@ -43,8 +43,8 @@ class DeltakelseStatistikkService(
         val (medKobling, utenKobling) = deltakelseInputs.partition { it.id in enhetKoblinger }
 
         logger.info(
-            "Koblingstabellen dekker ${medKobling.size} av ${deltakelseInputs.size} deltakelser. " +
-                    "${utenKobling.size} krever NOM-oppslag."
+            "Koblingstabellen dekker {} av {} deltakelser. {} krever NOM-oppslag.",
+            medKobling.size, deltakelseInputs.size, utenKobling.size
         )
 
         // Deltakelser med kobling → bruk enhetNavn direkte
@@ -66,6 +66,11 @@ class DeltakelseStatistikkService(
             val ressurserMedAlleTilknytninger: List<RessursMedAlleTilknytninger> =
                 nomApiService.hentResursserMedAlleTilknytninger(navIdenter)
 
+            logger.info(
+                "NOM returnerte {} ressurser for {} etterspurte identer",
+                ressurserMedAlleTilknytninger.size, navIdenter.size
+            )
+
             val nomResultat = deltakelsePerEnhetStatistikkTeller.tellAntallDeltakelserPerEnhet(
                 deltakelser = utenKobling,
                 ressurserMedTilknytninger = ressurserMedAlleTilknytninger
@@ -82,6 +87,12 @@ class DeltakelseStatistikkService(
         deltakelserPerEnhetFraNom.forEach { (enhet, antall) ->
             samletDeltakelserPerEnhet.merge(enhet, antall, Int::plus)
         }
+
+        // Logg endelig fordeling for feilsøking
+        val fordeling = samletDeltakelserPerEnhet.entries
+            .sortedByDescending { it.value }
+            .joinToString { "${it.key}: ${it.value}" }
+        logger.info("Statistikk-resultat fordeling: [{}]", fordeling)
 
         @Suppress("UNCHECKED_CAST")
         val diagnostikk = mapOf<Any, Any?>(
@@ -112,9 +123,15 @@ class DeltakelseStatistikkService(
     ) {
         val totalAntallDeltakelserStatistikk = statistikkRecords.sumOf { it.antallDeltakelser }
         if (kastFeilVedInkonsekventTelling && totalAntallDeltakelserStatistikk != alleDeltakelser.size) {
-            throw IllegalStateException("Inkonsekvent telling: Total antall deltakelser i statistikk ($totalAntallDeltakelserStatistikk) stemmer ikke overens med totalt antall deltakelser (${alleDeltakelser.size})")
+            throw IllegalStateException(
+                "Inkonsekvent telling: Total antall deltakelser i statistikk ($totalAntallDeltakelserStatistikk) " +
+                        "stemmer ikke overens med totalt antall deltakelser (${alleDeltakelser.size})"
+            )
         } else {
-            logger.info("Verifisert at total antall deltakelser i statistikk ($totalAntallDeltakelserStatistikk) stemmer overens med totalt antall deltakelser for enhetene (${alleDeltakelser.size})")
+            logger.info(
+                "Verifisert konsekvent telling: {} deltakelser i statistikk = {} totalt",
+                totalAntallDeltakelserStatistikk, alleDeltakelser.size
+            )
         }
     }
 }

--- a/app/src/main/resources/db/migration/V20__deltakelse_veileder_enhet.sql
+++ b/app/src/main/resources/db/migration/V20__deltakelse_veileder_enhet.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS deltakelse_veileder_enhet
+(
+    deltakelse_id       UUID PRIMARY KEY NOT NULL,
+    nav_ident           TEXT             NOT NULL,
+    enhet_id            TEXT             NOT NULL,
+    enhet_navn          TEXT             NOT NULL,
+    opprettet_tidspunkt TIMESTAMP        NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_deltakelse_veileder_enhet_deltakelse FOREIGN KEY (deltakelse_id)
+        REFERENCES ungdomsprogram_deltakelse (id)
+);
+
+CREATE INDEX idx_deltakelse_veileder_enhet_nav_ident ON deltakelse_veileder_enhet (nav_ident);
+

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
@@ -20,10 +20,12 @@ import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendR
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendService
 import no.nav.ung.deltakelseopplyser.domene.minside.mikrofrontend.MicrofrontendStatus
 import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseRepository
+import no.nav.ung.deltakelseopplyser.domene.register.DeltakelseVeilederEnhetService
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.domene.soknad.kafka.Ungdomsytelsesøknad
 import no.nav.ung.deltakelseopplyser.integration.abac.SifAbacPdpService
 import no.nav.ung.deltakelseopplyser.integration.kontoregister.KontoregisterService
+import no.nav.ung.deltakelseopplyser.integration.nom.api.NomApiService
 import no.nav.ung.deltakelseopplyser.integration.pdl.api.PdlService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngBrukerdialogService
 import no.nav.ung.deltakelseopplyser.integration.ungsak.UngSakService
@@ -58,6 +60,7 @@ import java.util.*
     UngdomsprogramregisterService::class,
     DeltakerappConfig::class,
     MicrofrontendService::class,
+    DeltakelseVeilederEnhetService::class
 )
 class UngdomsytelsesøknadServiceTest {
 
@@ -76,6 +79,9 @@ class UngdomsytelsesøknadServiceTest {
 
     @MockkBean
     lateinit var kontoregisterService: KontoregisterService
+
+    @MockkBean(relaxed = true)
+    lateinit var nomApiService: NomApiService
 
     @MockkBean
     lateinit var mineSiderService: MineSiderService

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkBeregnerTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkBeregnerTest.kt
@@ -398,7 +398,7 @@ class DeltakelseStatistikkBeregnerTest {
                             id = "1001",
                             navn = "NAV Oslo",
                             gyldigFom = LocalDate.parse("2020-01-01"),
-                            gyldigTom = LocalDate.parse("2025-09-30")
+                            gyldigTom = "2025-09-30".let { LocalDate.parse(it) }
                         )
                     ),
                     // Ny tilknytning som starter 20. oktober
@@ -423,6 +423,74 @@ class DeltakelseStatistikkBeregnerTest {
         // fordi den var siste gyldige enhet veilederen hadde
         assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Oslo", 1)
         assertThat(resultat.deltakelserPerEnhet).doesNotContainKey("NAV Bergen")
+    }
+
+    @Test
+    fun `skal bruke fremover-fallback når NOM-registrering kommer etter deltakelse-opprettelse`() {
+        // Gitt en deltakelse opprettet FØR veilederens NOM-tilknytning starter (innen 90 dager)
+        val deltakelser = listOf(
+            DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-10-09"))
+        )
+
+        val ressurserMedTilknytninger = listOf(
+            RessursMedAlleTilknytninger(
+                navIdent = "ABC123",
+                orgTilknytninger = listOf(
+                    // Tilknytning som starter 11 dager etter deltakelsesdato
+                    RessursOrgTilknytningMedPeriode(
+                        gyldigFom = LocalDate.parse("2025-10-20"),
+                        gyldigTom = null,
+                        orgEnhet = OrgEnhetMedPeriode(
+                            id = "1001",
+                            navn = "Skien Oppfølging ung",
+                            gyldigFom = LocalDate.parse("2025-10-01"),
+                            gyldigTom = null
+                        )
+                    )
+                )
+            )
+        )
+
+        // Når vi beregner antall deltakelser per enhet
+        val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
+
+        // Da skal deltakelsen mappes via fremover-fallback til den kommende enheten
+        assertThat(resultat.deltakelserPerEnhet).containsEntry("Skien Oppfølging ung", 1)
+        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT)
+    }
+
+    @Test
+    fun `skal ikke bruke fremover-fallback når gap er større enn toleranseperioden`() {
+        // Gitt en deltakelse opprettet mer enn 90 dager FØR veilederens NOM-tilknytning starter
+        val deltakelser = listOf(
+            DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-09-11"))
+        )
+
+        val ressurserMedTilknytninger = listOf(
+            RessursMedAlleTilknytninger(
+                navIdent = "ABC123",
+                orgTilknytninger = listOf(
+                    // Tilknytning som starter 112 dager etter deltakelsesdato (> 90 dager)
+                    RessursOrgTilknytningMedPeriode(
+                        gyldigFom = LocalDate.parse("2026-01-01"),
+                        gyldigTom = null,
+                        orgEnhet = OrgEnhetMedPeriode(
+                            id = "1001",
+                            navn = "Kristiansand Ungdom 1",
+                            gyldigFom = LocalDate.parse("2020-01-01"),
+                            gyldigTom = null
+                        )
+                    )
+                )
+            )
+        )
+
+        // Når vi beregner antall deltakelser per enhet
+        val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
+
+        // Da skal deltakelsen havne under "Enhet sikkerhetsnett" fordi gapet er for stort
+        assertThat(resultat.deltakelserPerEnhet).containsEntry(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT, 1)
+        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey("Kristiansand Ungdom 1")
     }
 
     @Test

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkBeregnerTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkBeregnerTest.kt
@@ -224,9 +224,10 @@ class DeltakelseStatistikkBeregnerTest {
     }
 
     @Test
-    fun `skal håndtere enheter som ikke er gyldige på deltakelsestidspunkt`() {
+    fun `skal bruke nærmeste tilknytning når enheter ikke er gyldige på deltakelsestidspunkt (strategi 4)`() {
         // Gitt en deltakelse hvor ingen enheter er gyldige på deltakelsesdatoen,
-        // og gapet er større enn toleranseperioden (90 dager)
+        // og gapet er større enn toleranseperioden (90 dager).
+        // Strategi 4 skal likevel finne nærmeste tilknytning.
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2024-08-15"))
         )
@@ -246,14 +247,14 @@ class DeltakelseStatistikkBeregnerTest {
                             gyldigTom = null
                         )
                     ),
-                    // Enhet som ikke var gyldig på deltakelsesdato
+                    // Tilknytning som er gyldig men orgEnheten starter etter deltakelsesdato
                     RessursOrgTilknytningMedPeriode(
                         gyldigFom = LocalDate.parse("2024-01-01"),
                         gyldigTom = null,
                         orgEnhet = OrgEnhetMedPeriode(
                             id = "1002",
                             navn = "NAV Bergen",
-                            gyldigFom = LocalDate.parse("2024-09-01"), // Starter etter deltakelsesdato
+                            gyldigFom = LocalDate.parse("2024-09-01"),
                             gyldigTom = null
                         )
                     )
@@ -261,13 +262,12 @@ class DeltakelseStatistikkBeregnerTest {
             )
         )
 
-        // Når vi beregner antall deltakelser per enhet
         val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
 
-        // Da skal deltakelsen telles under "Enhet sikkerhetsnett" siden ingen enheter var gyldige på tidspunktet
-        assertThat(resultat.deltakelserPerEnhet).containsEntry(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT, 1)
-        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey("NAV Oslo")
-        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey("NAV Bergen")
+        // Strategi 4 velger nærmeste tilknytning — tilknytning 2 (NAV Bergen) har avstand 0
+        // (deltakelsesdatoen er innenfor tilknytningsperioden), noe som er bedre enn sikkerhetsnett.
+        assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Bergen", 1)
+        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT)
     }
 
     @Test
@@ -460,8 +460,9 @@ class DeltakelseStatistikkBeregnerTest {
     }
 
     @Test
-    fun `skal ikke bruke fremover-fallback når gap er større enn toleranseperioden`() {
-        // Gitt en deltakelse opprettet mer enn 90 dager FØR veilederens NOM-tilknytning starter
+    fun `strategi 4 skal brukes når fremover-fallback gap er større enn toleranseperioden`() {
+        // Gitt en deltakelse opprettet mer enn 90 dager FØR veilederens NOM-tilknytning starter.
+        // Strategi 3 (90-dager fremover) matcher ikke, men strategi 4 (nærmeste ubegrenset) fanger den.
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-09-11"))
         )
@@ -485,12 +486,11 @@ class DeltakelseStatistikkBeregnerTest {
             )
         )
 
-        // Når vi beregner antall deltakelser per enhet
         val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
 
-        // Da skal deltakelsen havne under "Enhet sikkerhetsnett" fordi gapet er for stort
-        assertThat(resultat.deltakelserPerEnhet).containsEntry(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT, 1)
-        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey("Kristiansand Ungdom 1")
+        // Strategi 4 fanger denne — nærmeste tilknytning uavhengig av toleransegrense
+        assertThat(resultat.deltakelserPerEnhet).containsEntry("Kristiansand Ungdom 1", 1)
+        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT)
     }
 
     @Test
@@ -499,7 +499,7 @@ class DeltakelseStatistikkBeregnerTest {
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2024-01-15")),
             DeltakelseInput(UUID.randomUUID(), "UNKNOWN$VEILEDER_SUFFIX", LocalDate.parse("2024-01-16")),
-            DeltakelseInput(UUID.randomUUID(), "DEF456$VEILEDER_SUFFIX", LocalDate.parse("2024-08-15")) // Ingen gyldig enhet på dato (gap > 90 dager)
+            DeltakelseInput(UUID.randomUUID(), "DEF456$VEILEDER_SUFFIX", LocalDate.parse("2024-08-15")) // Gap > 90 dager, men strategi 4 finner nærmeste
         )
 
         val ressurserMedTilknytninger = listOf(
@@ -543,10 +543,139 @@ class DeltakelseStatistikkBeregnerTest {
         val totalSum = resultat.deltakelserPerEnhet.values.sum()
         assertThat(totalSum).isEqualTo(deltakelser.size)
 
-        // Og diagnostikken skal vise de umappede deltakelsene
+        // ABC123 → NAV Oslo, DEF456 → NAV Bergen (via strategi 4), UNKNOWN → sikkerhetsnett
+        assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Oslo", 1)
+        assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Bergen", 1)
+        assertThat(resultat.deltakelserPerEnhet).containsEntry(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT, 1)
+
+        // Diagnostikken viser kun UNKNOWN som umappet (DEF456 løst av strategi 4)
         @Suppress("UNCHECKED_CAST")
         val deltakelserUtenEnhet = resultat.diagnostikk["deltakelserUtenEnhet"] as Map<String, Any>
-        assertThat(deltakelserUtenEnhet["antall"]).isEqualTo(2) // UNKNOWN (ikke i NOM) + DEF456 (ingen gyldig enhet på dato)
+        assertThat(deltakelserUtenEnhet["antall"]).isEqualTo(1) // Kun UNKNOWN (ikke i NOM)
+    }
+
+    @Test
+    fun `strategi 4 - skal bruke nærmeste tilknytning fremover når gap er større enn 90 dager`() {
+        val deltakelser = listOf(
+            DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-06-01"))
+        )
+
+        val ressurserMedTilknytninger = listOf(
+            RessursMedAlleTilknytninger(
+                navIdent = "ABC123",
+                orgTilknytninger = listOf(
+                    // Tilknytning som starter 150 dager etter deltakelsesdato
+                    RessursOrgTilknytningMedPeriode(
+                        gyldigFom = LocalDate.parse("2025-10-29"),
+                        gyldigTom = null,
+                        orgEnhet = OrgEnhetMedPeriode(
+                            id = "1001",
+                            navn = "Skien Oppfølging ung",
+                            gyldigFom = LocalDate.parse("2025-10-01"),
+                            gyldigTom = null
+                        )
+                    )
+                )
+            )
+        )
+
+        val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
+
+        // Strategi 4 skal finne nærmeste tilknytning uavhengig av toleranse
+        assertThat(resultat.deltakelserPerEnhet).containsEntry("Skien Oppfølging ung", 1)
+        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT)
+    }
+
+    @Test
+    fun `strategi 4 - skal bruke nærmeste tilknytning bakover når gap er større enn 90 dager`() {
+        val deltakelser = listOf(
+            DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-12-01"))
+        )
+
+        val ressurserMedTilknytninger = listOf(
+            RessursMedAlleTilknytninger(
+                navIdent = "ABC123",
+                orgTilknytninger = listOf(
+                    RessursOrgTilknytningMedPeriode(
+                        gyldigFom = LocalDate.parse("2025-01-01"),
+                        gyldigTom = LocalDate.parse("2025-06-30"),
+                        orgEnhet = OrgEnhetMedPeriode(
+                            id = "1001",
+                            navn = "NAV Oslo",
+                            gyldigFom = LocalDate.parse("2020-01-01"),
+                            gyldigTom = null
+                        )
+                    )
+                )
+            )
+        )
+
+        val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
+
+        assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Oslo", 1)
+        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT)
+    }
+
+    @Test
+    fun `strategi 4 - skal velge nærmeste av flere tilknytninger utenfor toleranse`() {
+        val deltakelser = listOf(
+            DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-07-01"))
+        )
+
+        val ressurserMedTilknytninger = listOf(
+            RessursMedAlleTilknytninger(
+                navIdent = "ABC123",
+                orgTilknytninger = listOf(
+                    // 182 dager før
+                    RessursOrgTilknytningMedPeriode(
+                        gyldigFom = LocalDate.parse("2024-06-01"),
+                        gyldigTom = LocalDate.parse("2024-12-31"),
+                        orgEnhet = OrgEnhetMedPeriode(
+                            id = "1001",
+                            navn = "NAV Oslo",
+                            gyldigFom = LocalDate.parse("2020-01-01"),
+                            gyldigTom = null
+                        )
+                    ),
+                    // 123 dager etter — nærmere
+                    RessursOrgTilknytningMedPeriode(
+                        gyldigFom = LocalDate.parse("2025-11-01"),
+                        gyldigTom = null,
+                        orgEnhet = OrgEnhetMedPeriode(
+                            id = "1002",
+                            navn = "Skien Oppfølging ung",
+                            gyldigFom = LocalDate.parse("2025-10-01"),
+                            gyldigTom = null
+                        )
+                    )
+                )
+            )
+        )
+
+        val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
+
+        // Skien (123 dager) er nærmere enn Oslo (182 dager)
+        assertThat(resultat.deltakelserPerEnhet).containsEntry("Skien Oppfølging ung", 1)
+        assertThat(resultat.deltakelserPerEnhet).doesNotContainKey("NAV Oslo")
+    }
+
+    @Test
+    fun `skal håndtere veileder med tom orgTilknytning som sikkerhetsnett`() {
+        val deltakelser = listOf(
+            DeltakelseInput(UUID.randomUUID(), "H155556$VEILEDER_SUFFIX", LocalDate.parse("2025-10-15"))
+        )
+
+        val ressurserMedTilknytninger = listOf(
+            RessursMedAlleTilknytninger(
+                navIdent = "H155556",
+                orgTilknytninger = emptyList() // Har sluttet, ingen tilknytninger
+            )
+        )
+
+        val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
+
+        // Uten kobling i koblingstabellen og tom orgTilknytning → sikkerhetsnett
+        assertThat(resultat.deltakelserPerEnhet).containsEntry(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT, 1)
     }
 
 }

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkBeregnerTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkBeregnerTest.kt
@@ -224,10 +224,9 @@ class DeltakelseStatistikkBeregnerTest {
     }
 
     @Test
-    fun `skal bruke nærmeste tilknytning når enheter ikke er gyldige på deltakelsestidspunkt (strategi 4)`() {
-        // Gitt en deltakelse hvor ingen enheter er gyldige på deltakelsesdatoen,
-        // og gapet er større enn toleranseperioden (90 dager).
-        // Strategi 4 skal likevel finne nærmeste tilknytning.
+    fun `skal bruke nærmeste tilknytning når enheter ikke er gyldige på deltakelsestidspunkt`() {
+        // Gitt en deltakelse hvor ingen enheter er gyldige på deltakelsesdatoen.
+        // Nærmeste-tilknytning-fallback skal finne nærmeste tilknytning.
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2024-08-15"))
         )
@@ -264,7 +263,7 @@ class DeltakelseStatistikkBeregnerTest {
 
         val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
 
-        // Strategi 4 velger nærmeste tilknytning — tilknytning 2 (NAV Bergen) har avstand 0
+        // Nærmeste-tilknytning-fallback velger tilknytning 2 (NAV Bergen) som har avstand 0
         // (deltakelsesdatoen er innenfor tilknytningsperioden), noe som er bedre enn sikkerhetsnett.
         assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Bergen", 1)
         assertThat(resultat.deltakelserPerEnhet).doesNotContainKey(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT)
@@ -426,8 +425,8 @@ class DeltakelseStatistikkBeregnerTest {
     }
 
     @Test
-    fun `skal bruke fremover-fallback når NOM-registrering kommer etter deltakelse-opprettelse`() {
-        // Gitt en deltakelse opprettet FØR veilederens NOM-tilknytning starter (innen 90 dager)
+    fun `skal bruke nærmeste tilknytning når NOM-registrering kommer etter deltakelse-opprettelse`() {
+        // Gitt en deltakelse opprettet FØR veilederens NOM-tilknytning starter
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-10-09"))
         )
@@ -454,15 +453,15 @@ class DeltakelseStatistikkBeregnerTest {
         // Når vi beregner antall deltakelser per enhet
         val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
 
-        // Da skal deltakelsen mappes via fremover-fallback til den kommende enheten
+        // Da skal deltakelsen mappes via nærmeste-tilknytning-fallback til den kommende enheten
         assertThat(resultat.deltakelserPerEnhet).containsEntry("Skien Oppfølging ung", 1)
         assertThat(resultat.deltakelserPerEnhet).doesNotContainKey(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT)
     }
 
     @Test
-    fun `strategi 4 skal brukes når fremover-fallback gap er større enn toleranseperioden`() {
+    fun `skal bruke nærmeste tilknytning når gap er større enn 90 dager fremover`() {
         // Gitt en deltakelse opprettet mer enn 90 dager FØR veilederens NOM-tilknytning starter.
-        // Strategi 3 (90-dager fremover) matcher ikke, men strategi 4 (nærmeste ubegrenset) fanger den.
+        // Nærmeste-tilknytning-fallback fanger denne.
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-09-11"))
         )
@@ -488,7 +487,7 @@ class DeltakelseStatistikkBeregnerTest {
 
         val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
 
-        // Strategi 4 fanger denne — nærmeste tilknytning uavhengig av toleransegrense
+        // Nærmeste-tilknytning-fallback fanger denne — nærmeste tilknytning uavhengig av avstand
         assertThat(resultat.deltakelserPerEnhet).containsEntry("Kristiansand Ungdom 1", 1)
         assertThat(resultat.deltakelserPerEnhet).doesNotContainKey(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT)
     }
@@ -499,7 +498,7 @@ class DeltakelseStatistikkBeregnerTest {
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2024-01-15")),
             DeltakelseInput(UUID.randomUUID(), "UNKNOWN$VEILEDER_SUFFIX", LocalDate.parse("2024-01-16")),
-            DeltakelseInput(UUID.randomUUID(), "DEF456$VEILEDER_SUFFIX", LocalDate.parse("2024-08-15")) // Gap > 90 dager, men strategi 4 finner nærmeste
+            DeltakelseInput(UUID.randomUUID(), "DEF456$VEILEDER_SUFFIX", LocalDate.parse("2024-08-15")) // Gap > 90 dager, men nærmeste-tilknytning finner enheten
         )
 
         val ressurserMedTilknytninger = listOf(
@@ -543,19 +542,21 @@ class DeltakelseStatistikkBeregnerTest {
         val totalSum = resultat.deltakelserPerEnhet.values.sum()
         assertThat(totalSum).isEqualTo(deltakelser.size)
 
-        // ABC123 → NAV Oslo, DEF456 → NAV Bergen (via strategi 4), UNKNOWN → sikkerhetsnett
+        // ABC123 → NAV Oslo, DEF456 → NAV Bergen (via nærmeste tilknytning), UNKNOWN → sikkerhetsnett
         assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Oslo", 1)
         assertThat(resultat.deltakelserPerEnhet).containsEntry("NAV Bergen", 1)
         assertThat(resultat.deltakelserPerEnhet).containsEntry(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT, 1)
 
-        // Diagnostikken viser kun UNKNOWN som umappet (DEF456 løst av strategi 4)
+        // Diagnostikken viser kun UNKNOWN som umappet (DEF456 løst av nærmeste-tilknytning-fallback)
         @Suppress("UNCHECKED_CAST")
         val deltakelserUtenEnhet = resultat.diagnostikk["deltakelserUtenEnhet"] as Map<String, Any>
         assertThat(deltakelserUtenEnhet["antall"]).isEqualTo(1) // Kun UNKNOWN (ikke i NOM)
     }
 
     @Test
-    fun `strategi 4 - skal bruke nærmeste tilknytning fremover når gap er større enn 90 dager`() {
+    fun `nærmeste tilknytning - skal bruke nærmeste tilknytning fremover når gap er stort`() {
+        // Gitt en deltakelse opprettet mer enn 90 dager FØR veilederens NOM-tilknytning starter.
+        // Nærmeste-tilknytning-fallback skal finne nærmeste tilknytning uavhengig av avstand
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-06-01"))
         )
@@ -581,13 +582,14 @@ class DeltakelseStatistikkBeregnerTest {
 
         val resultat = beregner.tellAntallDeltakelserPerEnhet(deltakelser, ressurserMedTilknytninger)
 
-        // Strategi 4 skal finne nærmeste tilknytning uavhengig av toleranse
+        // Nærmeste-tilknytning-fallback skal finne nærmeste tilknytning uavhengig av avstand
         assertThat(resultat.deltakelserPerEnhet).containsEntry("Skien Oppfølging ung", 1)
         assertThat(resultat.deltakelserPerEnhet).doesNotContainKey(DeltakelsePerEnhetStatistikkTeller.ENHET_SIKKERHETSNETT)
     }
 
     @Test
-    fun `strategi 4 - skal bruke nærmeste tilknytning bakover når gap er større enn 90 dager`() {
+    fun `nærmeste tilknytning - skal bruke nærmeste tilknytning bakover når gap er stort`() {
+        // Gitt deltakelse som ligger i en gap-periode bakover i tid
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-12-01"))
         )
@@ -617,7 +619,8 @@ class DeltakelseStatistikkBeregnerTest {
     }
 
     @Test
-    fun `strategi 4 - skal velge nærmeste av flere tilknytninger utenfor toleranse`() {
+    fun `nærmeste tilknytning - skal velge nærmeste av flere tilknytninger`() {
+        // Gitt deltakelse hvor det finnes flere tilknytninger utenfor toleranse
         val deltakelser = listOf(
             DeltakelseInput(UUID.randomUUID(), "ABC123$VEILEDER_SUFFIX", LocalDate.parse("2025-07-01"))
         )


### PR DESCRIPTION
### **Behov / Bakgrunn**
Statistikk over antall deltakelser per NAV-enhet beregnes ved å slå opp veilederens organisasjonstilknytning i NOM (NAV Organisasjonsmaster) på deltakelsens opprettelsestidspunkt. Problemet er at NOM kun returnerer **nåværende** tilknytninger. Når en veileder slutter i NAV, returnerer NOM en tom `orgTilknytning`-liste, og alle deltakelser opprettet av den veilederen havner i «Enhet sikkerhetsnett» — en samlebøtte som gjør statistikken upresis.

I produksjon påvirket dette 44 av 592 deltakelser fordelt på 9 veiledere. For 8 av disse hadde NOM fortsatt tilknytningsdata, men med datoer utenfor 90-dagers toleransen. For 1 veileder var `orgTilknytning` helt tom.

### **Løsning**
#### 1. Koblingstabell `deltakelse_veileder_enhet`
Ny tabell som lagrer et **point-in-time snapshot** av hvilken enhet veilederen tilhørte da deltakelsen ble opprettet. Koblinger opprettes automatisk ved innmelding og brukes som primærkilde i statistikkberegningen. Deltakelser uten kobling faller tilbake til NOM-basert oppslag.

#### 2. Strategi 4 i `DeltakelsePerEnhetStatistikkTeller`
Ny fallback-strategi som velger **nærmeste tilknytning uten toleransegrense** når strategi 1–3 (eksakt match, bakover 90d, fremover 90d) feiler. Beregner absolutt avstand i dager og velger den med kortest avstand. Dette løser de 8 veilederne som hadde tilknytninger utenfor 90-dagers toleransen.

#### 3. Diagnostikk-endepunkter for manuell korrigering
- `POST /diagnostikk/backfill/deltakelse-veileder-enhet` — fyller koblingstabellen for eksisterende deltakelser basert på NOM-data
- `PUT /diagnostikk/deltakelse-veileder-enhet/{deltakelseId}` — manuell upsert av enhet-kobling (for veiledere uten NOM-data)
- `GET /diagnostikk/deltakelse-veileder-enhet/{deltakelseId}` — hent kobling for en deltakelse

### **Andre endringer**
- `UngdomsprogramregisterService.leggTilIProgram()` — lagrer veileder→enhet-kobling etter persistering av deltakelse, wrappet i try-catch slik at NOM-feil ikke blokkerer innmelding
- `DeltakelseStatistikkService` — bruker koblingstabellen som primærkilde og faller tilbake til NOM kun for deltakelser uten kobling. Diagnostikk-output oppdatert med `antallMedKobling`/`antallUtenKobling`
- Eksisterende tester oppdatert for å reflektere at strategi 4 nå resolver deltakelser som tidligere havnet i sikkerhetsnett
- 4 nye tester for strategi 4 (fremover, bakover, nærmeste av flere, tom orgTilknytning)

### Etter deploy

1. Kall `POST /diagnostikk/backfill/deltakelse-veileder-enhet` for å fylle koblingstabellen for eksisterende deltakelser
2. Bruk `PUT /diagnostikk/deltakelse-veileder-enhet/{deltakelseId}` for veiledere med tom `orgTilknytning` i NOM