### PR TITLE
Konsolider enhet-popularitet og forbedre backfill av koblingstabell for deltakelse-veileder-enhet

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetRepository.kt
@@ -6,5 +6,17 @@ import java.util.*
 interface DeltakelseVeilederEnhetRepository : JpaRepository<DeltakelseVeilederEnhetDAO, UUID> {
     fun findAllByDeltakelseIdIn(deltakelseIder: List<UUID>): List<DeltakelseVeilederEnhetDAO>
     fun findByDeltakelseId(deltakelseId: UUID): DeltakelseVeilederEnhetDAO?
+
+    @org.springframework.data.jpa.repository.Query(
+        "SELECT d.enhetId AS enhetId, d.enhetNavn AS enhetNavn, COUNT(d) AS antall " +
+                "FROM DeltakelseVeilederEnhetDAO d GROUP BY d.enhetId, d.enhetNavn"
+    )
+    fun hentEnhetPopularitet(): List<EnhetPopularitetProjection>
+}
+
+interface EnhetPopularitetProjection {
+    val enhetId: String
+    val enhetNavn: String
+    val antall: Long
 }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetService.kt
@@ -38,6 +38,9 @@ class DeltakelseVeilederEnhetService(
     /**
      * Prøver å resolve veilederens nåværende enhet fra NOM og lagre koblingen.
      * Feiler stille (try-catch) slik at innmeldingen ikke blokkeres.
+     *
+     * Når veilederen har flere gyldige enheter (f.eks. ungdomsteam + kontaktsenter),
+     * velges den mest populære enheten blant alle veiledere i NOM-datasettet.
      */
     fun prøvLagreEnhetForDeltakelse(deltakelseId: UUID, navIdent: String) {
         try {
@@ -53,8 +56,8 @@ class DeltakelseVeilederEnhetService(
             }
 
             val dato = LocalDate.now()
-            val enhet = resolveGyldigEnhet(ressurs, dato)
-            if (enhet == null) {
+            val kandidater = resolveGyldigeEnheter(ressurs, dato)
+            if (kandidater.isEmpty()) {
                 val tilknytninger = ressurs.orgTilknytninger.joinToString { t ->
                     "${t.orgEnhet.navn} (${t.gyldigFom}–${t.gyldigTom ?: "løpende"})"
                 }
@@ -64,6 +67,20 @@ class DeltakelseVeilederEnhetService(
                     deltakelseId, navIdent, dato, ressurs.orgTilknytninger.size, tilknytninger
                 )
                 return
+            }
+
+            // Disambiguer ved flere gyldige enheter — bruk popularitet
+            val enhet = if (kandidater.size > 1) {
+                val enhetPopularitet = beregnEnhetPopularitet(ressurser)
+                val valgt = velgMestPopulær(kandidater, enhetPopularitet)
+                logger.info(
+                    "Deltakelse {}: NAV-ident {} har {} gyldige enheter på {}, velger mest populære: {} ({}). Kandidater: [{}]",
+                    deltakelseId, navIdent, kandidater.size, dato, valgt.navn, valgt.id,
+                    kandidater.joinToString { "${it.navn} (${it.id})" }
+                )
+                valgt
+            } else {
+                kandidater.first()
             }
 
             deltakelseVeilederEnhetRepository.save(
@@ -115,25 +132,36 @@ class DeltakelseVeilederEnhetService(
 
     /**
      * Backfill: Lagrer enhets-koblinger for en liste med deltakelser basert på NOM-data.
-     * Returnerer resultat med antall vellykkede/feilede koblinger.
+     * Bruker popularitets-disambiguering for å velge riktig enhet når en veileder har
+     * flere samtidige tilknytninger (f.eks. ungdomsteam + kontaktsenter).
+     *
+     * @param force Hvis true, overskriver eksisterende koblinger. Nyttig for re-backfill.
      */
     fun backfillEnhetKoblinger(
         deltakelser: List<BackfillInput>,
         ressurserMedTilknytninger: List<RessursMedAlleTilknytninger>,
+        force: Boolean = false,
     ): BackfillResultat {
-        val eksisterendeKoblinger = deltakelseVeilederEnhetRepository
-            .findAllByDeltakelseIdIn(deltakelser.map { it.deltakelseId })
-            .map { it.deltakelseId }
-            .toSet()
+        val eksisterendeKoblinger = if (force) {
+            emptySet()
+        } else {
+            deltakelseVeilederEnhetRepository
+                .findAllByDeltakelseIdIn(deltakelser.map { it.deltakelseId })
+                .map { it.deltakelseId }
+                .toSet()
+        }
 
         val ressursLookup = ressurserMedTilknytninger.associateBy { it.navIdent }
+        val enhetPopularitet = beregnEnhetPopularitet(ressurserMedTilknytninger)
+
         var antallOpprettet = 0
+        var antallOppdatert = 0
         var antallHoppetOver = 0
         val identerUtenRessurs = mutableSetOf<String>()
         val identerUtenGyldigEnhet = mutableSetOf<String>()
 
         deltakelser.forEach { input ->
-            if (input.deltakelseId in eksisterendeKoblinger) {
+            if (!force && input.deltakelseId in eksisterendeKoblinger) {
                 antallHoppetOver++
                 return@forEach
             }
@@ -144,9 +172,8 @@ class DeltakelseVeilederEnhetService(
                 return@forEach
             }
 
-            // Bruk nærmeste tilknytning uten toleransegrense for historiske deltakelser
-            val enhet = resolveNærmesteEnhet(ressurs, input.opprettetDato)
-            if (enhet == null) {
+            val kandidater = resolveGyldigeEnheter(ressurs, input.opprettetDato)
+            if (kandidater.isEmpty()) {
                 identerUtenGyldigEnhet.add(input.navIdent)
                 logger.debug(
                     "Backfill: Ingen gyldig enhet for NAV-ident {} på {} (deltakelseId={}, antallTilknytninger={})",
@@ -155,70 +182,92 @@ class DeltakelseVeilederEnhetService(
                 return@forEach
             }
 
-            deltakelseVeilederEnhetRepository.save(
-                DeltakelseVeilederEnhetDAO(
-                    deltakelseId = input.deltakelseId,
-                    navIdent = input.navIdent,
-                    enhetId = enhet.id,
-                    enhetNavn = enhet.navn,
+            val enhet = if (kandidater.size > 1) {
+                val valgt = velgMestPopulær(kandidater, enhetPopularitet)
+                logger.debug(
+                    "Backfill: NAV-ident {} har {} kandidater på {}, velger {} ({})",
+                    input.navIdent, kandidater.size, input.opprettetDato, valgt.navn, valgt.id
                 )
-            )
-            antallOpprettet++
+                valgt
+            } else {
+                kandidater.first()
+            }
+
+            if (force) {
+                oppdaterEnhetKobling(input.deltakelseId, input.navIdent, enhet.id, enhet.navn)
+                antallOppdatert++
+            } else {
+                deltakelseVeilederEnhetRepository.save(
+                    DeltakelseVeilederEnhetDAO(
+                        deltakelseId = input.deltakelseId,
+                        navIdent = input.navIdent,
+                        enhetId = enhet.id,
+                        enhetNavn = enhet.navn,
+                    )
+                )
+                antallOpprettet++
+            }
         }
 
         val feiledeIdenter = identerUtenRessurs + identerUtenGyldigEnhet
         logger.info(
-            "Backfill ferdig: {} opprettet, {} hoppet over (eksisterte), {} feilet " +
+            "Backfill ferdig (force={}): {} opprettet, {} oppdatert, {} hoppet over (eksisterte), {} feilet " +
                     "(ingen NOM-ressurs: {}, ingen gyldig enhet: {})",
-            antallOpprettet, antallHoppetOver, feiledeIdenter.size,
+            force, antallOpprettet, antallOppdatert, antallHoppetOver, feiledeIdenter.size,
             identerUtenRessurs, identerUtenGyldigEnhet
         )
-        return BackfillResultat(antallOpprettet, antallHoppetOver, feiledeIdenter)
+        return BackfillResultat(antallOpprettet, antallOppdatert, antallHoppetOver, feiledeIdenter)
     }
 
     /**
-     * Finner gyldig enhet for en veileder på en gitt dato.
-     * Eksakt match, deretter bakover/fremover-fallback med 90 dager.
+     * Finner alle gyldige enheter for en veileder på en gitt dato.
+     * Returnerer en liste slik at kalleren kan disambiguere (f.eks. via popularitet).
+     *
+     * Strategier:
+     * 1. Eksakt match: Tilknytning og orgEnhet begge gyldige på datoen.
+     * 2. Nærmeste tilknytning: Korteste absolutte avstand til datoen.
      */
-    private fun resolveGyldigEnhet(ressurs: RessursMedAlleTilknytninger, dato: LocalDate): OrgEnhetMedPeriode? {
-        val eksaktGyldig = ressurs.orgTilknytninger
+    private fun resolveGyldigeEnheter(ressurs: RessursMedAlleTilknytninger, dato: LocalDate): List<OrgEnhetMedPeriode> {
+        if (ressurs.orgTilknytninger.isEmpty()) return emptyList()
+
+        val eksaktGyldige = ressurs.orgTilknytninger
             .filter { it.erGyldigPåTidspunkt(dato) }
             .map { it.orgEnhet }
             .filter { it.erGyldigPåTidspunkt(dato) }
-            .firstOrNull()
+            .distinctBy { "${it.id}-${it.navn}" }
 
-        if (eksaktGyldig != null) return eksaktGyldig
+        if (eksaktGyldige.isNotEmpty()) return eksaktGyldige
 
-        val toleranseDager = 90L
-        return ressurs.orgTilknytninger
-            .mapNotNull { tilknytning ->
-                val avstand = beregnAvstand(tilknytning.gyldigFom, tilknytning.gyldigTom, dato)
-                if (avstand <= toleranseDager) tilknytning.orgEnhet to avstand else null
-            }
-            .minByOrNull { it.second }
-            ?.first
-    }
-
-    /**
-     * Finner nærmeste tilknytning uten toleransegrense.
-     * Brukes for backfill av historiske deltakelser.
-     */
-    private fun resolveNærmesteEnhet(ressurs: RessursMedAlleTilknytninger, dato: LocalDate): OrgEnhetMedPeriode? {
-        if (ressurs.orgTilknytninger.isEmpty()) return null
-
-        val eksaktGyldig = ressurs.orgTilknytninger
-            .filter { it.erGyldigPåTidspunkt(dato) }
-            .map { it.orgEnhet }
-            .filter { it.erGyldigPåTidspunkt(dato) }
-            .firstOrNull()
-
-        if (eksaktGyldig != null) return eksaktGyldig
-
-        return ressurs.orgTilknytninger
+        val tilknytningerMedAvstand = ressurs.orgTilknytninger
             .map { tilknytning -> tilknytning.orgEnhet to beregnAvstand(tilknytning.gyldigFom, tilknytning.gyldigTom, dato) }
-            .minByOrNull { it.second }
-            ?.first
+            .sortedBy { it.second }
+
+        val minAvstand = tilknytningerMedAvstand.firstOrNull()?.second ?: return emptyList()
+
+        // Returner alle med samme minimale avstand (kan være flere like nære)
+        return tilknytningerMedAvstand
+            .filter { it.second == minAvstand }
+            .map { it.first }
+            .distinctBy { "${it.id}-${it.navn}" }
     }
+
+    /**
+     * Beregner popularitet per enhet: antall ganger enheten forekommer som tilknytning
+     * på tvers av alle veiledere. Brukes for å disambiguere når en veileder har flere enheter.
+     */
+    private fun beregnEnhetPopularitet(ressurser: List<RessursMedAlleTilknytninger>): Map<String, Int> =
+        ressurser
+            .flatMap { it.orgTilknytninger }
+            .map { it.orgEnhet }
+            .groupingBy { "${it.id}-${it.navn}" }
+            .eachCount()
+
+    /**
+     * Velger den mest populære enheten fra en liste med kandidater.
+     * Faller tilbake til første enhet hvis ingen popularitetsdata finnes.
+     */
+    private fun velgMestPopulær(kandidater: List<OrgEnhetMedPeriode>, popularitet: Map<String, Int>): OrgEnhetMedPeriode =
+        kandidater.maxByOrNull { popularitet["${it.id}-${it.navn}"] ?: 0 } ?: kandidater.first()
 
     /**
      * Beregner den absolutte avstanden i dager mellom en tilknytningsperiode og en dato.
@@ -240,6 +289,7 @@ class DeltakelseVeilederEnhetService(
 
     data class BackfillResultat(
         val antallOpprettet: Int,
+        val antallOppdatert: Int,
         val antallHoppetOver: Int,
         val feiledeNavIdenter: Set<String>,
     )

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseVeilederEnhetService.kt
@@ -69,9 +69,9 @@ class DeltakelseVeilederEnhetService(
                 return
             }
 
-            // Disambiguer ved flere gyldige enheter — bruk popularitet
+            // Disambiguer ved flere gyldige enheter — bruk popularitet fra koblingstabellen
             val enhet = if (kandidater.size > 1) {
-                val enhetPopularitet = beregnEnhetPopularitet(ressurser)
+                val enhetPopularitet = hentEnhetPopularitetFraKoblingstabellen()
                 val valgt = velgMestPopulær(kandidater, enhetPopularitet)
                 logger.info(
                     "Deltakelse {}: NAV-ident {} har {} gyldige enheter på {}, velger mest populære: {} ({}). Kandidater: [{}]",
@@ -152,7 +152,7 @@ class DeltakelseVeilederEnhetService(
         }
 
         val ressursLookup = ressurserMedTilknytninger.associateBy { it.navIdent }
-        val enhetPopularitet = beregnEnhetPopularitet(ressurserMedTilknytninger)
+        val enhetPopularitet = hentEnhetPopularitetFraKoblingstabellen()
 
         var antallOpprettet = 0
         var antallOppdatert = 0
@@ -251,16 +251,6 @@ class DeltakelseVeilederEnhetService(
             .distinctBy { "${it.id}-${it.navn}" }
     }
 
-    /**
-     * Beregner popularitet per enhet: antall ganger enheten forekommer som tilknytning
-     * på tvers av alle veiledere. Brukes for å disambiguere når en veileder har flere enheter.
-     */
-    private fun beregnEnhetPopularitet(ressurser: List<RessursMedAlleTilknytninger>): Map<String, Int> =
-        ressurser
-            .flatMap { it.orgTilknytninger }
-            .map { it.orgEnhet }
-            .groupingBy { "${it.id}-${it.navn}" }
-            .eachCount()
 
     /**
      * Velger den mest populære enheten fra en liste med kandidater.
@@ -279,6 +269,16 @@ class DeltakelseVeilederEnhetService(
             gyldigTom != null && dato.isAfter(gyldigTom) -> ChronoUnit.DAYS.between(gyldigTom, dato)
             else -> 0L
         }
+    }
+
+    /**
+     * Henter enhet-popularitet fra koblingstabellen (antall deltakelser per enhet).
+     * Brukes for å disambiguere når en veileder har flere gyldige enheter.
+     * Returnerer map med nøkkel "enhetId-enhetNavn" og antall koblinger som verdi.
+     */
+    fun hentEnhetPopularitetFraKoblingstabellen(): Map<String, Int> {
+        return deltakelseVeilederEnhetRepository.hentEnhetPopularitet()
+            .associate { "${it.enhetId}-${it.enhetNavn}" to it.antall.toInt() }
     }
 
     data class BackfillInput(

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/drift/DiagnostikkDriftController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/drift/DiagnostikkDriftController.kt
@@ -182,9 +182,11 @@ class DiagnostikkDriftController(
     // === Koblingstabellen deltakelse → veileder → enhet ===
 
     @PostMapping("/backfill/deltakelse-veileder-enhet", produces = [MediaType.APPLICATION_JSON_VALUE])
-    @Operation(summary = "Backfill koblingstabellen deltakelse→veileder→enhet basert på NOM-data for alle deltakelser som mangler kobling")
+    @Operation(summary = "Backfill koblingstabellen deltakelse→veileder→enhet basert på NOM-data. Bruk force=true for å overskrive eksisterende koblinger.")
     @ResponseStatus(HttpStatus.OK)
-    fun backfillDeltakelseVeilederEnhet(): Map<String, Any> {
+    fun backfillDeltakelseVeilederEnhet(
+        @RequestParam(defaultValue = "false") force: Boolean,
+    ): Map<String, Any> {
         tilgangskontrollService.krevDriftsTilgang(BeskyttetRessursActionAttributt.CREATE)
 
         val alleDeltakelser = deltakelseRepository.findAll()
@@ -200,13 +202,15 @@ class DiagnostikkDriftController(
         val navIdenter = backfillInputs.map { it.navIdent }.toSet()
         val ressurser = nomApiService.hentResursserMedAlleTilknytninger(navIdenter)
 
-        val resultat = deltakelseVeilederEnhetService.backfillEnhetKoblinger(backfillInputs, ressurser)
+        val resultat = deltakelseVeilederEnhetService.backfillEnhetKoblinger(backfillInputs, ressurser, force)
 
         return mapOf(
             "totalDeltakelser" to alleDeltakelser.size,
             "antallOpprettet" to resultat.antallOpprettet,
+            "antallOppdatert" to resultat.antallOppdatert,
             "antallHoppetOver" to resultat.antallHoppetOver,
             "feiledeNavIdenter" to resultat.feiledeNavIdenter,
+            "force" to force,
         )
     }
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelsePerEnhetStatistikkTeller.kt
@@ -49,6 +49,7 @@ class DeltakelsePerEnhetStatistikkTeller {
     fun tellAntallDeltakelserPerEnhet(
         deltakelser: List<DeltakelseInput>,
         ressurserMedTilknytninger: List<RessursMedAlleTilknytninger>,
+        enhetPopularitet: Map<String, Int> = emptyMap(),
     ): DeltakelsePerEnhetResultat {
         // Oppslag-map for rask lookup av NOM-ressurs per NAV-ident
         val ressursLookup = ressurserMedTilknytninger.associateBy { it.navIdent }
@@ -59,14 +60,14 @@ class DeltakelsePerEnhetStatistikkTeller {
         // som fallback slik at ingen deltakelser går tapt fra tellingen.
         val deltakelserPerEnhet = deltakelser
             .map { deltakelse ->
-                finnEnhetForDeltakelse(deltakelse, ressursLookup, ressurserMedTilknytninger, veiledereMedFlereEnheter)
+                finnEnhetForDeltakelse(deltakelse, ressursLookup, enhetPopularitet, veiledereMedFlereEnheter)
                     ?: ENHET_SIKKERHETSNETT.also { deltakelserUtenEnhet.add(deltakelse) }
             }
             // Grupper enhetsnavn og tell forekomster: "NAV Oslo" -> 82, "NAV Bergen" -> 67, osv.
             .groupingBy { it }
             .eachCount()
 
-        return opprettResultat(deltakelser, deltakelserPerEnhet, veiledereMedFlereEnheter, ressurserMedTilknytninger, deltakelserUtenEnhet)
+        return opprettResultat(deltakelser, deltakelserPerEnhet, veiledereMedFlereEnheter, enhetPopularitet, deltakelserUtenEnhet)
     }
 
     /**
@@ -80,7 +81,7 @@ class DeltakelsePerEnhetStatistikkTeller {
     private fun finnEnhetForDeltakelse(
         deltakelse: DeltakelseInput,
         ressursLookup: Map<String, RessursMedAlleTilknytninger>,
-        alleRessurser: List<RessursMedAlleTilknytninger>,
+        enhetPopularitet: Map<String, Int>,
         veiledereMedFlereEnheter: MutableMap<String, List<OrgEnhetMedPeriode>>,
     ): String? {
         val navIdent = deltakelse.navIdent()
@@ -110,7 +111,7 @@ class DeltakelsePerEnhetStatistikkTeller {
             else -> {
                 val valgtEnhet = velgMestPopulæreEnhet(
                     gyldigeEnheter,
-                    alleRessurser,
+                    enhetPopularitet,
                     navIdent,
                     deltakelse.opprettetDato,
                     veiledereMedFlereEnheter
@@ -189,14 +190,12 @@ class DeltakelsePerEnhetStatistikkTeller {
      */
     private fun velgMestPopulæreEnhet(
         gyldigeEnheter: List<OrgEnhetMedPeriode>,
-        alleRessurser: List<RessursMedAlleTilknytninger>,
+        enhetPopularitet: Map<String, Int>,
         navIdent: String,
         opprettetDato: LocalDate,
         veiledereMedFlereEnheter: MutableMap<String, List<OrgEnhetMedPeriode>>,
     ): OrgEnhetMedPeriode {
-        // Tell hvor mange tilknytninger hver enhet har totalt på tvers av alle veiledere
-        val enhetPopularitet = beregnEnhetPopularitet(alleRessurser)
-        // Velg enheten med flest tilknytninger totalt
+        // Velg enheten med flest koblinger i koblingstabellen
         val mestPopulæreEnhet = gyldigeEnheter.maxByOrNull {
             enhetPopularitet["${it.id}-${it.navn}"] ?: 0
         } ?: gyldigeEnheter.first()
@@ -207,16 +206,6 @@ class DeltakelsePerEnhetStatistikkTeller {
         return mestPopulæreEnhet
     }
 
-    /**
-     * Beregner popularitet per enhet: antall ganger enheten forekommer som tilknytning
-     * på tvers av alle veiledere. Brukes for å disambiguere når en veileder har flere enheter.
-     */
-    private fun beregnEnhetPopularitet(ressurserMedTilknytninger: List<RessursMedAlleTilknytninger>): Map<String, Int> =
-        ressurserMedTilknytninger
-            .flatMap { it.orgTilknytninger }
-            .map { it.orgEnhet }
-            .groupingBy { "${it.id}-${it.navn}" }
-            .eachCount()
 
     private fun loggFlereEnheterValg(
         gyldigeEnheter: List<OrgEnhetMedPeriode>,
@@ -240,7 +229,7 @@ class DeltakelsePerEnhetStatistikkTeller {
         deltakelser: List<DeltakelseInput>,
         deltakelserPerEnhet: Map<String, Int>,
         veiledereMedFlereEnheter: Map<String, List<OrgEnhetMedPeriode>>,
-        ressurserMedTilknytninger: List<RessursMedAlleTilknytninger>,
+        enhetPopularitet: Map<String, Int>,
         deltakelserUtenEnhet: List<DeltakelseInput>,
     ): DeltakelsePerEnhetResultat {
         val antallUnikeNavIdenter = deltakelser
@@ -264,7 +253,7 @@ class DeltakelsePerEnhetStatistikkTeller {
         return DeltakelsePerEnhetResultat(
             deltakelserPerEnhet = deltakelserPerEnhet,
             diagnostikk = mapOf(
-                "enhetPopularitet" to beregnEnhetPopularitet(ressurserMedTilknytninger),
+                "enhetPopularitet" to enhetPopularitet,
                 "veiledereMedFlereEnheter" to veiledereMedFlereEnheter,
                 "totalAntallDeltakelser" to deltakelser.size,
                 "antallUnikeNavIdenter" to antallUnikeNavIdenter,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/statistikk/deltakelse/DeltakelseStatistikkService.kt
@@ -71,9 +71,12 @@ class DeltakelseStatistikkService(
                 ressurserMedAlleTilknytninger.size, navIdenter.size
             )
 
+            val enhetPopularitet = deltakelseVeilederEnhetService.hentEnhetPopularitetFraKoblingstabellen()
+
             val nomResultat = deltakelsePerEnhetStatistikkTeller.tellAntallDeltakelserPerEnhet(
                 deltakelser = utenKobling,
-                ressurserMedTilknytninger = ressurserMedAlleTilknytninger
+                ressurserMedTilknytninger = ressurserMedAlleTilknytninger,
+                enhetPopularitet = enhetPopularitet,
             )
             deltakelserPerEnhetFraNom = nomResultat.deltakelserPerEnhet
             nomDiagnostikk = nomResultat.diagnostikk


### PR DESCRIPTION
Disambiguering ved flere gyldige enheter for en veileder brukte tre
ulike popularitetsberegninger (NOM-basert i service, NOM-basert i
statistikkteller, og koblingstabellen ved innmelding). Konsolidert
til én kilde: deltakelse_veileder_enhet-tabellen via
hentEnhetPopularitetFraKoblingstabellen().

Endringer:
- DeltakelseVeilederEnhetRepository: ny JPQL-query hentEnhetPopularitet()
- DeltakelseVeilederEnhetService: fjernet beregnEnhetPopularitet(NOM),
  bruker koblingstabellen i innmelding, backfill og statistikk
- DeltakelsePerEnhetStatistikkTeller: fjernet egen beregnEnhetPopularitet,
  mottar popularitetsmap som parameter
- DeltakelseStatistikkService: sender koblingstabellens popularitet til telleren
- Backfill støtter force=true for å overskrive eksisterende koblinger
- BackfillResultat inkluderer nå antallOppdatert i tillegg til antallOpprettet
