### PR TITLE
Omdøp forlengetPeriodeMaksDato til periodeMaksDato i DeltakelseDTO og relaterte klasser

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -61,7 +61,7 @@ class UngdomsprogramregisterService(
                 erSlettet = erSlettet,
                 harOpphørsvedtak = harOpphørsvedtak,
                 harForlengetPeriode = harForlengetPeriode,
-                forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(getFom(), harForlengetPeriode).tilOgMed
+                periodeMaksDato = ForlengetPeriodeBeregner.beregn(getFom(), harForlengetPeriode).tilOgMed
             )
         }
     }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramRegisterVeilederController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/veileder/UngdomsprogramRegisterVeilederController.kt
@@ -65,7 +65,7 @@ class UngdomsprogramRegisterVeilederController(
         val deltakelseDTO = DeltakelseDTO(
             deltaker = DeltakerDTO(deltakerIdent = deltakelseInnmeldingDTO.deltakerIdent),
             fraOgMed = deltakelseInnmeldingDTO.startdato,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseInnmeldingDTO.startdato).tilOgMed
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseInnmeldingDTO.startdato).tilOgMed
         )
 
         return registerService.leggTilIProgram(deltakelseDTO).also {

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -85,7 +85,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = startdato,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -103,7 +103,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
         )
 
         every { pdlService.hentFolkeregisteridenter(any()) } returns listOf(
@@ -118,7 +118,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
             ungdomsprogramregisterService.leggTilIProgram(
                 dto.copy(
                     fraOgMed = onsdag,
-                    forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
+                    periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
                 )
             )
         }
@@ -130,7 +130,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = DeltakerDTO(UUID.randomUUID(), "02499435811"),
             fraOgMed = programDato.minusDays(2),
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(programDato.minusDays(2)).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(programDato.minusDays(2)).tilOgMed,
         )
 
         every { pdlService.hentFolkeregisteridenter(any()) } returns listOf(
@@ -153,7 +153,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = DeltakerDTO(UUID.randomUUID(), "02499435811"),
             fraOgMed = tjuveniårsdag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(tjuveniårsdag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(tjuveniårsdag).tilOgMed,
         )
 
         every { pdlService.hentFolkeregisteridenter(any()) } returns listOf(
@@ -176,7 +176,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = deltakelseStartdato,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
             tilOgMed = deltakelseStartdato.plusDays(10),
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
@@ -193,7 +193,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = deltakelseStartdato,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -214,7 +214,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = deltakelseStartdato,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -238,7 +238,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -264,7 +264,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -288,7 +288,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -300,7 +300,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val oppdatertDto = DeltakelseDTO(
             deltaker = innmelding.deltaker,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
             tilOgMed = onsdag,
         )
         ungdomsprogramregisterService.avsluttDeltakelse(innmelding.id!!, oppdatertDto)
@@ -323,7 +323,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -335,7 +335,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val oppdatertDto = DeltakelseDTO(
             deltaker = innmelding.deltaker,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
             tilOgMed = onsdag,
         )
         ungdomsprogramregisterService.avsluttDeltakelse(innmelding.id!!, oppdatertDto)
@@ -355,7 +355,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = deltakelseStartdato,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
         )
         ungdomsprogramregisterService.leggTilIProgram(dto)
         assertThrows<DataIntegrityViolationException> { ungdomsprogramregisterService.leggTilIProgram(dto) }
@@ -369,7 +369,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = deltakelseStartdato,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
         )
         every { pdlService.hentAktørIder(any()) } returns listOf(
             IdentInformasjon("321", false, IdentGruppe.AKTORID),
@@ -407,7 +407,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -430,7 +430,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -438,7 +438,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
             innmelding.id!!, DeltakelseDTO(
                 deltaker = innmelding.deltaker,
                 fraOgMed = mandag,
-                forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+                periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
                 tilOgMed = mandag.plusDays(100),
             )
         )
@@ -462,7 +462,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
 
@@ -486,7 +486,7 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed,
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
         ungdomsprogramregisterService.forlengPeriode(innmelding.id!!)

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/historikk/DeltakelseHistorikkServiceTest.kt
@@ -92,7 +92,7 @@ class DeltakelseHistorikkServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto) // Fører til første historikkinnslag
         assertThat(innmelding.id).isNotNull
@@ -114,7 +114,7 @@ class DeltakelseHistorikkServiceTest : AbstractIntegrationTest() {
                 deltaker = innmelding.deltaker,
                 fraOgMed = onsdag,
                 tilOgMed = onsdag,
-                forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
+                periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
             )
         ) // Fører til fjerde historikkinnslag
 
@@ -253,7 +253,7 @@ class DeltakelseHistorikkServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto) // Fører til første historikkinnslag
         assertThat(innmelding.id).isNotNull
@@ -285,7 +285,7 @@ class DeltakelseHistorikkServiceTest : AbstractIntegrationTest() {
         val dto = DeltakelseDTO(
             deltaker = deltakerDTO,
             fraOgMed = mandag,
-            forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
+            periodeMaksDato = ForlengetPeriodeBeregner.beregn(mandag).tilOgMed
         )
         val innmelding = ungdomsprogramregisterService.leggTilIProgram(dto)
         val deltakelseId = innmelding.id!!

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelseSøknadTransaksjonsTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelseSøknadTransaksjonsTest.kt
@@ -298,7 +298,7 @@ class UngdomsytelseSøknadTransaksjonsTest : AbstractIntegrationTest() {
             DeltakelseDTO(
                 deltaker = DeltakerDTO(deltakerIdent = søkerIdent),
                 fraOgMed = startdato,
-                forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed
+                periodeMaksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed
             )
         )
     }

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/UngdomsytelsesøknadServiceTest.kt
@@ -154,7 +154,7 @@ class UngdomsytelsesøknadServiceTest : AbstractIntegrationTest() {
             deltakelseDTO = DeltakelseDTO(
                 deltaker = DeltakerDTO(deltakerIdent = søkerIdent),
                 fraOgMed = LocalDate.parse(deltakelseStart),
-                forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(LocalDate.parse(deltakelseStart)).tilOgMed
+                periodeMaksDato = ForlengetPeriodeBeregner.beregn(LocalDate.parse(deltakelseStart)).tilOgMed
             )
         )
     }

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/kafka/UngdomsytelsesøknadKonsumentTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/soknad/kafka/UngdomsytelsesøknadKonsumentTest.kt
@@ -77,7 +77,7 @@ class UngdomsytelsesøknadKonsumentTest : AbstractIntegrationTest() {
             DeltakelseDTO(
                 deltaker = DeltakerDTO(deltakerIdent = deltakerIdent),
                 fraOgMed = startdato,
-                forlengetPeriodeMaksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed
+                periodeMaksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed
             )
         )
 

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/register/DeltakelseDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/register/DeltakelseDTO.kt
@@ -39,15 +39,15 @@ data class DeltakelseDTO(
     val periodeMaksDato: LocalDate
 ) {
 
-    /** @deprecated Bruk [harForlengetPeriode]. Beholdt for bakoverkompatibilitet. */
-    @Deprecated("Bruk harForlengetPeriode", ReplaceWith("harForlengetPeriode"))
-    @get:JsonProperty("harUtvidetKvote")
-    val harUtvidetKvote: Boolean get() = harForlengetPeriode
-
     /** @deprecated Bruk [periodeMaksDato]. Beholdt for bakoverkompatibilitet. */
     @Deprecated("Bruk periodeMaksDato", ReplaceWith("periodeMaksDato"))
     @get:JsonProperty("forlengetPeriodeMaksDato")
     val forlengetPeriodeMaksDato: LocalDate get() = periodeMaksDato
+
+    /** @deprecated Bruk [harForlengetPeriode]. Beholdt for bakoverkompatibilitet. */
+    @Deprecated("Bruk harForlengetPeriode", ReplaceWith("harForlengetPeriode"))
+    @get:JsonProperty("harUtvidetKvote")
+    val harUtvidetKvote: Boolean get() = harForlengetPeriode
 
     /** @deprecated Bruk [periodeMaksDato]. Beholdt for bakoverkompatibilitet. */
     @Deprecated("Bruk periodeMaksDato", ReplaceWith("periodeMaksDato"))

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/register/DeltakelseDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/register/DeltakelseDTO.kt
@@ -34,9 +34,9 @@ data class DeltakelseDTO(
     @JsonProperty("søktTidspunkt")
     val søktTidspunkt: ZonedDateTime? = null,
 
-    @JsonProperty("forlengetPeriodeMaksDato")
-    @JsonAlias("kvoteMaksDato")
-    val forlengetPeriodeMaksDato: LocalDate
+    @JsonProperty("periodeMaksDato")
+    @JsonAlias("forlengetPeriodeMaksDato", "kvoteMaksDato")
+    val periodeMaksDato: LocalDate
 ) {
 
     /** @deprecated Bruk [harForlengetPeriode]. Beholdt for bakoverkompatibilitet. */
@@ -44,10 +44,15 @@ data class DeltakelseDTO(
     @get:JsonProperty("harUtvidetKvote")
     val harUtvidetKvote: Boolean get() = harForlengetPeriode
 
-    /** @deprecated Bruk [forlengetPeriodeMaksDato]. Beholdt for bakoverkompatibilitet. */
-    @Deprecated("Bruk forlengetPeriodeMaksDato", ReplaceWith("forlengetPeriodeMaksDato"))
+    /** @deprecated Bruk [periodeMaksDato]. Beholdt for bakoverkompatibilitet. */
+    @Deprecated("Bruk periodeMaksDato", ReplaceWith("periodeMaksDato"))
+    @get:JsonProperty("forlengetPeriodeMaksDato")
+    val forlengetPeriodeMaksDato: LocalDate get() = periodeMaksDato
+
+    /** @deprecated Bruk [periodeMaksDato]. Beholdt for bakoverkompatibilitet. */
+    @Deprecated("Bruk periodeMaksDato", ReplaceWith("periodeMaksDato"))
     @get:JsonProperty("kvoteMaksDato")
-    val kvoteMaksDato: LocalDate get() = forlengetPeriodeMaksDato
+    val kvoteMaksDato: LocalDate get() = periodeMaksDato
 
     override fun toString(): String =
         "DeltakelseDTO(id=$id, fraOgMed=$fraOgMed, tilOgMed=$tilOgMed)"


### PR DESCRIPTION
### Behov / Bakgrunn
Navnet på feltet er misvisende da maksdato er satt uavhengig om det er forlenget periode eller ei.

### Løsning

Renamer feltet.

---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
