### PR TITLE
chore: bump ung-sak version to 7.7.2 in pom.xml

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -21,7 +21,7 @@
         <logback.logstash.version>9.0</logback.logstash.version>
         <spring-mockk.version>5.0.1</spring-mockk.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <ung-sak.version>7.7.1</ung-sak.version>
+        <ung-sak.version>7.7.2</ung-sak.version>
         <ung-brukerdialog-api.version>1.0.3</ung-brukerdialog-api.version>
 
         <fp-sak.version>2.7.4</fp-sak.version>

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -21,7 +21,7 @@ import no.nav.ung.sak.kontrakt.hendelser.HendelseInfo
 import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramEndretStartdatoHendelse
 import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramFjernDeltakelseHendelse
 import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramOpphørHendelse
-import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramUtvidetKvoteHendelse
+import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramForlengetPeriodeHendelse
 import no.nav.ung.sak.typer.AktørId
 import no.nav.ung.sak.typer.Periode
 import org.slf4j.LoggerFactory
@@ -533,7 +533,7 @@ class UngdomsprogramregisterService(
             hendelseInfo.leggTilAktør(AktørId(it.ident))
         }
 
-        val hendelse = UngdomsprogramUtvidetKvoteHendelse(
+        val hendelse = UngdomsprogramForlengetPeriodeHendelse(
             hendelseInfo.build(),
             Periode(forlengetFraOgMed, forlengetTilOgMed)
         )


### PR DESCRIPTION
### Behov / Bakgrunn

`UngdomsprogramUtvidetKvoteHendelse` er utgått og skal ikke lenger brukes.

### Løsning

- Bumper ung-sak-kontakt.
- Erstatter `UngdomsprogramUtvidetKvoteHendelse` med `UngdomsprogramForlengetPeriodeHendelse`.

---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
