### PR TITLE
TSFF-2699 - Legger til endepunkt for å hente alle deltakelser for veilarbportefolje

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseRepository.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/DeltakelseRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.ung.deltakelseopplyser.domene.register
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import java.util.*
 
 interface DeltakelseRepository : JpaRepository<DeltakelseDAO, UUID> {
@@ -9,4 +10,12 @@ interface DeltakelseRepository : JpaRepository<DeltakelseDAO, UUID> {
 
     fun findByIdAndDeltaker_IdIn(id: UUID, deltakerIds: List<UUID>): DeltakelseDAO?
 
+    @Query(
+        """
+        SELECT d FROM ungdomsprogram_deltakelse d
+        JOIN FETCH d.deltaker
+        WHERE d.erSlettet = false
+        """
+    )
+    fun findAlleIkkeSlettet(): List<DeltakelseDAO>
 }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -277,6 +277,14 @@ class UngdomsprogramregisterService(
         return ungdomsprogramDAOs.map { it.mapToDTO() }
     }
 
+    @Transactional(TRANSACTION_MANAGER, readOnly = true)
+    fun hentAlleDeltakelser(): List<DeltakelseDTO> {
+        logger.info("Henter alle deltakelser.")
+        val deltakelser = deltakelseRepository.findAlleIkkeSlettet()
+        logger.info("Fant ${deltakelser.size} deltakelser.")
+        return deltakelser.map { it.mapToDTO() }
+    }
+
     @Transactional(TRANSACTION_MANAGER)
     fun avsluttDeltakelse(
         id: UUID,

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ekstern/EksternDeltakelseController.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ekstern/EksternDeltakelseController.kt
@@ -11,10 +11,16 @@ import no.nav.ung.deltakelseopplyser.config.Issuers
 import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterService
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakelseSjekk
+import no.nav.ung.deltakelseopplyser.kontrakt.ekstern.AlleDeltakelserResponseDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.ekstern.DeltakelseInfoDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.ekstern.DeltakelsePeriodeDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.ekstern.DeltakerIdent
 import org.springframework.core.env.Environment
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
+import org.springframework.web.ErrorResponseException
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -28,9 +34,8 @@ import org.springframework.web.bind.annotation.RestController
 )
 @Tag(
     name = "Ekstern deltakelse",
-    description = """API for å sjekke om en bruker er aktiv deltaker i ungdomsprogrammet.
-        Støtter både OBO-token (veileder) og systemtoken / M2M (maskin-til-maskin).
-        Returnerer alltid HTTP 200 – sjekk feltet 'erDeltaker' for svar."""
+    description = """API for oppslag av deltakelse i ungdomsprogrammet.
+        Støtter både OBO-token (veileder) og systemtoken / M2M (maskin-til-maskin)."""
 )
 class EksternDeltakelseController(
     private val sporingsloggService: SporingsloggService,
@@ -39,12 +44,22 @@ class EksternDeltakelseController(
     environment: Environment,
 ) {
 
-    private val godkjenteApplikasjoner: List<String> = buildList {
+    private val godkjenteApplikasjonerSjekk: List<String> = buildList {
         add("veilarboppfolging")
         if (environment.activeProfiles.contains("dev-gcp")) {
             add("azure-token-generator")
         }
     }
+
+    private val godkjenteApplikasjonerAlle: List<String> = buildList {
+        add("veilarbportefolje")
+        if (environment.activeProfiles.contains("dev-gcp")) {
+            add("azure-token-generator")
+        }
+    }
+
+    private val hentAlleDeltakelserEnabled: Boolean =
+        !environment.activeProfiles.contains("prod-gcp")
 
     @PostMapping(
         "/sjekk",
@@ -66,10 +81,10 @@ class EksternDeltakelseController(
         val erSystemkall = tilgangskontrollService.erSystemBruker()
 
         if (erSystemkall) {
-            tilgangskontrollService.krevSystemtilgang(godkjenteApplikasjoner)
+            tilgangskontrollService.krevSystemtilgang(godkjenteApplikasjonerSjekk)
         } else {
             tilgangskontrollService.krevOboTilgangFraGodkjentEksternSystem(
-                godkjenteApplikasjoner,
+                godkjenteApplikasjonerSjekk,
                 personIdent
             )
         }
@@ -85,5 +100,45 @@ class EksternDeltakelseController(
                     )
                 }
             }
+    }
+
+    @GetMapping(
+        "/alle",
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    @Operation(
+        summary = "Hent alle deltakelser i ungdomsprogrammet",
+        description = """Returnerer alle (ikke-slettede) deltakelser i ungdomsprogrammet med periode og forlengelsesinfo.
+            Kun tilgjengelig for systemtoken (M2M / client_credentials).
+            Kallet må komme fra et godkjent system (sjekkes via azp-claim)."""
+    )
+    @ResponseStatus(HttpStatus.OK)
+    fun hentAlleDeltakelser(): AlleDeltakelserResponseDTO {
+        if (!hentAlleDeltakelserEnabled) {
+            throw ErrorResponseException(
+                HttpStatus.NOT_FOUND,
+                ProblemDetail.forStatus(HttpStatus.NOT_FOUND),
+                null
+            )
+        }
+
+        tilgangskontrollService.krevSystemtilgang(godkjenteApplikasjonerAlle)
+
+        val deltakelser = registerService.hentAlleDeltakelser()
+
+        return AlleDeltakelserResponseDTO(
+            deltakelser = deltakelser.map { deltakelse ->
+                DeltakelseInfoDTO(
+                    deltakelseId = deltakelse.id!!,
+                    deltakerIdent = deltakelse.deltaker.deltakerIdent,
+                    periode = DeltakelsePeriodeDTO(
+                        fraOgMed = deltakelse.fraOgMed,
+                        tilOgMed = deltakelse.tilOgMed,
+                        harForlengetPeriode = deltakelse.harForlengetPeriode,
+                        periodeMaksDato = deltakelse.periodeMaksDato,
+                    ),
+                )
+            }
+        )
     }
 }

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ekstern/EksternDeltakelseControllerTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ekstern/EksternDeltakelseControllerTest.kt
@@ -358,6 +358,28 @@ class EksternDeltakelseControllerTest {
         assertThat(response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
     }
 
+    @Test
+    fun `hentAlleDeltakelser - OBO-token avvises med 403 fordi kun M2M er tillatt`() {
+        every { tilgangskontrollService.krevSystemtilgang(any()) } throws
+            ErrorResponseException(
+                HttpStatus.FORBIDDEN,
+                ProblemDetail.forStatusAndDetail(
+                    HttpStatus.FORBIDDEN,
+                    "Systemtjenesten er ikke tilgjengelig for innlogget bruker"
+                ),
+                null
+            )
+
+        val response = testRestTemplate.exchange(
+            "/ekstern/deltakelse/alle",
+            HttpMethod.GET,
+            HttpEntity<Void>(azureOboToken()),
+            String::class.java
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+    }
+
     // ── helpers ────────────────────────────────────────────────────────────────
 
     private fun azureSystemToken(): HttpHeaders =

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ekstern/EksternDeltakelseControllerTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/ekstern/EksternDeltakelseControllerTest.kt
@@ -12,6 +12,8 @@ import no.nav.ung.deltakelseopplyser.domene.register.UngdomsprogramregisterServi
 import no.nav.ung.deltakelseopplyser.integration.abac.TilgangskontrollService
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakerDTO
 import no.nav.ung.deltakelseopplyser.kontrakt.deltaker.DeltakelseSjekk
+import no.nav.ung.deltakelseopplyser.kontrakt.ekstern.AlleDeltakelserResponseDTO
+import no.nav.ung.deltakelseopplyser.kontrakt.register.DeltakelseDTO
 import no.nav.ung.deltakelseopplyser.statistikk.bigquery.BigQueryTestConfiguration
 import no.nav.ung.deltakelseopplyser.utils.FødselsnummerGenerator
 import no.nav.ung.deltakelseopplyser.utils.TokenTestUtils.hentToken
@@ -267,6 +269,89 @@ class EksternDeltakelseControllerTest {
                 DeltakerDTO(deltakerIdent = deltakerIdent),
                 bearerHeaders(mockOAuth2Server.hentToken(issuerId = "ukjent"))
             ),
+            String::class.java
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+    }
+
+    // ── GET /ekstern/deltakelse/alle ──────────────────────────────────────────
+
+    @Test
+    fun `hentAlleDeltakelser - systemtoken returnerer alle deltakelser`() {
+        every { tilgangskontrollService.krevSystemtilgang(any()) } just runs
+        every { registerService.hentAlleDeltakelser() } returns listOf(
+            DeltakelseDTO(
+                id = java.util.UUID.randomUUID(),
+                deltaker = DeltakerDTO(deltakerIdent = deltakerIdent),
+                fraOgMed = LocalDate.of(2025, 1, 1),
+                tilOgMed = null,
+                harForlengetPeriode = false,
+                periodeMaksDato = LocalDate.of(2026, 1, 1),
+            )
+        )
+
+        val response = testRestTemplate.exchange(
+            "/ekstern/deltakelse/alle",
+            HttpMethod.GET,
+            HttpEntity<Void>(azureSystemToken()),
+            AlleDeltakelserResponseDTO::class.java
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body!!.deltakelser).hasSize(1)
+        val deltakelse = response.body!!.deltakelser.first()
+        assertThat(deltakelse.deltakerIdent).isEqualTo(deltakerIdent)
+        assertThat(deltakelse.periode.fraOgMed).isEqualTo(LocalDate.of(2025, 1, 1))
+        assertThat(deltakelse.periode.tilOgMed).isNull()
+        assertThat(deltakelse.periode.harForlengetPeriode).isFalse()
+        assertThat(deltakelse.periode.periodeMaksDato).isEqualTo(LocalDate.of(2026, 1, 1))
+    }
+
+    @Test
+    fun `hentAlleDeltakelser - tom liste naar ingen deltakelser finnes`() {
+        every { tilgangskontrollService.krevSystemtilgang(any()) } just runs
+        every { registerService.hentAlleDeltakelser() } returns emptyList()
+
+        val response = testRestTemplate.exchange(
+            "/ekstern/deltakelse/alle",
+            HttpMethod.GET,
+            HttpEntity<Void>(azureSystemToken()),
+            AlleDeltakelserResponseDTO::class.java
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body!!.deltakelser).isEmpty()
+    }
+
+    @Test
+    fun `hentAlleDeltakelser - ikke-godkjent system gir 403`() {
+        every { tilgangskontrollService.krevSystemtilgang(any()) } throws
+            ErrorResponseException(
+                HttpStatus.FORBIDDEN,
+                ProblemDetail.forStatusAndDetail(
+                    HttpStatus.FORBIDDEN,
+                    "Systemtjenesten er ikke tilgjengelig for innlogget bruker"
+                ),
+                null
+            )
+
+        val response = testRestTemplate.exchange(
+            "/ekstern/deltakelse/alle",
+            HttpMethod.GET,
+            HttpEntity<Void>(azureSystemToken()),
+            String::class.java
+        )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+    }
+
+    @Test
+    fun `hentAlleDeltakelser - uten token gir 401`() {
+        val response = testRestTemplate.exchange(
+            "/ekstern/deltakelse/alle",
+            HttpMethod.GET,
+            HttpEntity<Void>(HttpHeaders()),
             String::class.java
         )
 

--- a/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/ekstern/DeltakelseInfoDTO.kt
+++ b/kontrakt/src/main/kotlin/no/nav/ung/deltakelseopplyser/kontrakt/ekstern/DeltakelseInfoDTO.kt
@@ -1,0 +1,23 @@
+package no.nav.ung.deltakelseopplyser.kontrakt.ekstern
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDate
+import java.util.*
+
+data class DeltakelsePeriodeDTO(
+    @JsonProperty("fraOgMed") val fraOgMed: LocalDate,
+    @JsonProperty("tilOgMed") val tilOgMed: LocalDate? = null,
+    @JsonProperty("harForlengetPeriode") val harForlengetPeriode: Boolean,
+    @JsonProperty("periodeMaksDato") val periodeMaksDato: LocalDate,
+)
+
+data class DeltakelseInfoDTO(
+    @JsonProperty("deltakelseId") val deltakelseId: UUID,
+    @JsonProperty("deltakerIdent") val deltakerIdent: String,
+    @JsonProperty("periode") val periode: DeltakelsePeriodeDTO,
+)
+
+data class AlleDeltakelserResponseDTO(
+    @JsonProperty("deltakelser") val deltakelser: List<DeltakelseInfoDTO>,
+)
+

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -72,6 +72,11 @@
       "app": "veilarboppfolging",
       "namespace": "poao",
       "cluster": "dev-gcp"
+    },
+    {
+      "app": "veilarbportefolje",
+      "namespace": "obo",
+      "cluster": "dev-gcp"
     }
   ],
   "database": {

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -52,6 +52,11 @@
       "app": "veilarboppfolging",
       "namespace": "poao",
       "cluster": "prod-gcp"
+    },
+    {
+      "app": "veilarbportefolje",
+      "namespace": "obo",
+      "cluster": "prod-gcp"
     }
   ],
   "database": {


### PR DESCRIPTION
### Behov / Bakgrunn

Team Obo (veilarbportefolje) trenger å vite hvilke brukere som er deltakere i ungdomsprogrammet for å kunne filtrere i Oversikten. De har ~380 000 personer under oppfølging, og enkeltoppslag per person skalerer ikke. Med ~600 aktive deltakere er et bulk-endepunkt som returnerer alle deltakelser i én respons den enkleste løsningen i første runde — Kafka-hendelser kan komme senere.

Se også tråd i slack: https://nav-it.slack.com/archives/C067J3PUHS9/p1779443706915079

### Løsning

Nytt endepunkt: `GET /ekstern/deltakelse/alle`

- Returnerer alle ikke-slettede deltakelser med deltakelseId, deltakerIdent og periode (fraOgMed, tilOgMed, harForlengetPeriode, periodeMaksDato)
- Kun M2M (systemtoken / client_credentials)
- Tilgang begrenset til `veilarbportefolje`

### Andre endringer

- Inbound access policy for `veilarbportefolje` (namespace: obo) i dev-gcp og prod-gcp
- Ny repository-metode `findAlleIkkeSlettet()` med JOIN FETCH
- Ny service-metode `hentAlleDeltakelser()`
- Tester for det nye endepunktet (happy path, tom liste, 403, 401)


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
