### PR TITLE
Fikser outbound-rules for populasjonstilgangskontroll.

### DIFF
--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -50,7 +50,8 @@ spec:
         - application: ung-brukerdialog-api
         - application: k9-selvbetjening-oppslag
         - application: sif-abac-pdp
-        - application: tilgangsmaskin
+        - application: populasjonstilgangskontroll
+          namespace: tilgangsmaskin
         - application: sokos-kontoregister-person
           namespace: okonomi
       external:


### PR DESCRIPTION
### Behov / Bakgrunn

https://nav-it.slack.com/archives/CNGKVQVJ9/p1779371201315149

### Løsning

Fikser navnet på applikasjonen.
Denne spiller ingen rolle da vi kaller tjenesten med ingress, men vises riktig i nais console.


### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
