### PR TITLE
TSFF-2757: Setter oppgave til avbrutt ved sletting av deltakelse

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -194,7 +194,7 @@ class UngdomsprogramregisterService(
                 }
 
             ikkeSøkteDeltakelser.forEach { deltakelse ->
-                ungBrukerdialogService.settAvbruttSøkYtelseOppgaveForTypeOgPeriode(
+                val ok = ungBrukerdialogService.settAvbruttSøkYtelseOppgaveForTypeOgPeriode(
                     EndreOppgaveStatusDto(
                         no.nav.ung.brukerdialog.typer.AktørId(aktørId.ident),
                         OppgaveType.SØK_YTELSE,
@@ -202,6 +202,12 @@ class UngdomsprogramregisterService(
                         deltakelse.tilOgMed,
                     )
                 )
+
+                if (!ok) {
+                    logger.warn(
+                        "Klarte ikke å sette SøkYtelse-oppgave til avbrutt for deltaker ${deltaker.id} og periode ${deltakelse.fraOgMed}..${deltakelse.tilOgMed}. Fortsetter med sletting."
+                    )
+                }
             }
         } catch (e: org.springframework.web.client.HttpClientErrorException) {
             if (e.statusCode == HttpStatus.UNAUTHORIZED || e.statusCode == HttpStatus.FORBIDDEN) {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -1,6 +1,8 @@
 package no.nav.ung.deltakelseopplyser.domene.register
 
 import io.hypersistence.utils.hibernate.type.range.Range
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.EndreOppgaveStatusDto
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveType
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveYtelsetype
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OpprettOppgaveDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.søkytelse.SøkYtelseOppgavetypeDataDto
@@ -150,6 +152,8 @@ class UngdomsprogramregisterService(
         val deltakelseIder = deltakelser.mapNotNull { it.id }
         deltakelseVeilederEnhetService.slettForDeltakelser(deltakelseIder)
 
+        settAvbruttSøkYtelseOppgaverForDeltakelser(deltaker, deltakelser)
+
         val deltakerSlettet = deltakerService.slettDeltaker(deltakerId)
         if (!deltakerSlettet) {
             logger.error("Klarte ikke å slette deltaker med id $deltakerId fra deltakerregisteret")
@@ -175,6 +179,33 @@ class UngdomsprogramregisterService(
         }
 
         return true
+    }
+
+    private fun settAvbruttSøkYtelseOppgaverForDeltakelser(deltaker: DeltakerDAO, deltakelser: List<DeltakelseDTO>) {
+        val ikkeSøkteDeltakelser = deltakelser.filter { it.søktTidspunkt == null }
+        if (ikkeSøkteDeltakelser.isEmpty()) return
+
+        try {
+            val aktørId = pdlService.hentAktørIder(deltaker.deltakerIdent)
+                .firstOrNull { !it.historisk }
+                ?: run {
+                    logger.warn("Fant ingen aktiv aktørId for deltaker ${deltaker.id}. Kan ikke sette SøkYtelse-oppgaver til avbrutt.")
+                    return
+                }
+
+            ikkeSøkteDeltakelser.forEach { deltakelse ->
+                ungBrukerdialogService.settAvbruttSøkYtelseOppgaveForTypeOgPeriode(
+                    EndreOppgaveStatusDto(
+                        no.nav.ung.brukerdialog.typer.AktørId(aktørId.ident),
+                        OppgaveType.SØK_YTELSE,
+                        deltakelse.fraOgMed,
+                        deltakelse.tilOgMed,
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            logger.warn("Klarte ikke å sette SøkYtelse-oppgaver til avbrutt for deltaker ${deltaker.id}. Fortsetter med sletting.", e)
+        }
     }
 
     @Transactional(TRANSACTION_MANAGER)

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -203,6 +203,11 @@ class UngdomsprogramregisterService(
                     )
                 )
             }
+        } catch (e: org.springframework.web.client.HttpClientErrorException) {
+            if (e.statusCode == HttpStatus.UNAUTHORIZED || e.statusCode == HttpStatus.FORBIDDEN) {
+                throw e
+            }
+            logger.warn("Klarte ikke å sette SøkYtelse-oppgaver til avbrutt for deltaker ${deltaker.id}. Fortsetter med sletting.", e)
         } catch (e: Exception) {
             logger.warn("Klarte ikke å sette SøkYtelse-oppgaver til avbrutt for deltaker ${deltaker.id}. Fortsetter med sletting.", e)
         }

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/ungsak/UngBrukerdialogService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/integration/ungsak/UngBrukerdialogService.kt
@@ -1,5 +1,6 @@
 package no.nav.ung.deltakelseopplyser.integration.ungsak
 
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.EndreOppgaveStatusDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OpprettOppgaveDto
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -43,6 +44,24 @@ class UngBrukerdialogService(
             false
         }
     }
+
+    fun settAvbruttSøkYtelseOppgaveForTypeOgPeriode(dto: EndreOppgaveStatusDto): Boolean {
+        return try {
+            ungBrukerdialogRetryClient.settAvbruttForTypeOgPeriode(dto)
+        } catch (exception: HttpClientErrorException) {
+            if (exception.statusCode == HttpStatus.UNAUTHORIZED || exception.statusCode == HttpStatus.FORBIDDEN) {
+                throw exception
+            }
+            logger.error("Fikk en HttpClientErrorException når man kalte sett-avbrutt-for-type-og-periode i ung-brukerdialog-api. Error response = '${exception.responseBodyAsString}'")
+            false
+        } catch (_: HttpServerErrorException) {
+            logger.error("Fikk en HttpServerErrorException når man kalte sett-avbrutt-for-type-og-periode i ung-brukerdialog-api.")
+            false
+        } catch (_: ResourceAccessException) {
+            logger.error("Fikk en ResourceAccessException når man kalte sett-avbrutt-for-type-og-periode i ung-brukerdialog-api.")
+            false
+        }
+    }
 }
 
 @Component
@@ -59,12 +78,24 @@ class UngBrukerdialogRetryClient(
 ) {
     private companion object {
         private const val opprettSøkYtelseUrl = "/intern/api/oppgavebehandling/opprett"
+        private const val settAvbruttForTypeOgPeriodeUrl = "/intern/api/oppgavebehandling/sett-avbrutt-for-type-og-periode"
     }
 
     fun opprettSøkYtelseOppgave(opprettOppgave: OpprettOppgaveDto): Boolean {
         val httpEntity = HttpEntity(opprettOppgave)
         val response = ungBrukerdialogKlient.exchange(
             opprettSøkYtelseUrl,
+            HttpMethod.POST,
+            httpEntity,
+            Unit::class.java
+        )
+        return response.statusCode == HttpStatus.OK
+    }
+
+    fun settAvbruttForTypeOgPeriode(dto: EndreOppgaveStatusDto): Boolean {
+        val httpEntity = HttpEntity(dto)
+        val response = ungBrukerdialogKlient.exchange(
+            settAvbruttForTypeOgPeriodeUrl,
             HttpMethod.POST,
             httpEntity,
             Unit::class.java

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -1,6 +1,7 @@
 package no.nav.ung.deltakelseopplyser.domene.register
 
 import com.ninjasquad.springmockk.MockkBean
+import com.github.tomakehurst.wiremock.client.WireMock
 import io.mockk.every
 import no.nav.pdl.generated.enums.IdentGruppe
 import no.nav.pdl.generated.hentident.IdentInformasjon
@@ -224,6 +225,45 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         assertTrue(utmelding)
         assertThat(deltakelseRepository.findByDeltaker_IdIn(listOf(innmelding.deltaker.id!!))).isEmpty()
         assertThat(deltakelseVeilederEnhetRepository.findByDeltakelseId(innmelding.id!!)).isNull()
+    }
+
+    @Test
+    fun `Fjerner deltaker setter SøkYtelse-oppgave til avbrutt`() {
+        val fnr = FødselsnummerGenerator.neste()
+        val deltakerDTO = DeltakerDTO(deltakerIdent = fnr)
+
+        every { pdlService.hentFolkeregisteridenter(any()) } returns listOf(
+            IdentInformasjon(fnr, false, IdentGruppe.FOLKEREGISTERIDENT))
+        every { pdlService.hentAktørIder(any()) } returns listOf(
+            IdentInformasjon("321", false, IdentGruppe.AKTORID),
+            IdentInformasjon("451", true, IdentGruppe.AKTORID)
+        )
+
+        wireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo("/ung-brukerdialog-api-mock/ung/brukerdialog/intern/api/oppgavebehandling/sett-avbrutt-for-type-og-periode"))
+                .willReturn(WireMock.aResponse().withStatus(HttpStatus.OK.value()))
+        )
+
+        val deltakelseStartdato = LocalDate.now()
+        val innmelding = ungdomsprogramregisterService.leggTilIProgram(
+            DeltakelseDTO(
+                deltaker = deltakerDTO,
+                fraOgMed = deltakelseStartdato,
+                periodeMaksDato = ForlengetPeriodeBeregner.beregn(deltakelseStartdato).tilOgMed,
+            )
+        )
+
+        val deltakerDAO = deltakerRepository.finnDeltakerGittIdenter(listOf(fnr)).firstOrNull()
+        assertThat(deltakerDAO).isNotNull
+
+        val utmelding = ungdomsprogramregisterService.fjernFraProgram(deltakerDAO!!)
+
+        assertTrue(utmelding)
+        wireMockServer.verify(
+            WireMock.postRequestedFor(
+                WireMock.urlPathEqualTo("/ung-brukerdialog-api-mock/ung/brukerdialog/intern/api/oppgavebehandling/sett-avbrutt-for-type-og-periode")
+            )
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/ungsak/UngBrukerdialogServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/ungsak/UngBrukerdialogServiceTest.kt
@@ -5,6 +5,8 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.ninjasquad.springmockk.MockkBean
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.EndreOppgaveStatusDto
+import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveType
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OppgaveYtelsetype
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.OpprettOppgaveDto
 import no.nav.ung.brukerdialog.kontrakt.oppgaver.typer.søkytelse.SøkYtelseOppgavetypeDataDto
@@ -57,6 +59,7 @@ class UngBrukerdialogServiceTest {
 
     private companion object {
         const val OPPRETT_SØK_YTELSE_PATH = "/ung-brukerdialog-api-mock/ung/brukerdialog/intern/api/oppgavebehandling/opprett"
+        const val SETT_AVBRUTT_FOR_TYPE_OG_PERIODE_PATH = "/ung-brukerdialog-api-mock/ung/brukerdialog/intern/api/oppgavebehandling/sett-avbrutt-for-type-og-periode"
     }
 
     @Test
@@ -93,6 +96,44 @@ class UngBrukerdialogServiceTest {
                 UUID.randomUUID(),
                 SøkYtelseOppgavetypeDataDto(LocalDate.now()),
                 null
+            )
+        )
+
+        assertThat(resultat).isFalse()
+    }
+
+    @Test
+    fun `settAvbruttSøkYtelseOppgaveForTypeOgPeriode returnerer true ved vellykket kall`() {
+        wireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo(SETT_AVBRUTT_FOR_TYPE_OG_PERIODE_PATH))
+                .willReturn(WireMock.aResponse().withStatus(HttpStatus.OK.value()))
+        )
+
+        val resultat = ungBrukerdialogService.settAvbruttSøkYtelseOppgaveForTypeOgPeriode(
+            EndreOppgaveStatusDto(
+                AktørId("1234567890123"),
+                OppgaveType.SØK_YTELSE,
+                LocalDate.now(),
+                null,
+            )
+        )
+
+        assertThat(resultat).isTrue()
+    }
+
+    @Test
+    fun `settAvbruttSøkYtelseOppgaveForTypeOgPeriode returnerer false ved klientfeil`() {
+        wireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo(SETT_AVBRUTT_FOR_TYPE_OG_PERIODE_PATH))
+                .willReturn(WireMock.aResponse().withStatus(HttpStatus.BAD_REQUEST.value()))
+        )
+
+        val resultat = ungBrukerdialogService.settAvbruttSøkYtelseOppgaveForTypeOgPeriode(
+            EndreOppgaveStatusDto(
+                AktørId("1234567890123"),
+                OppgaveType.SØK_YTELSE,
+                LocalDate.now(),
+                null,
             )
         )
 


### PR DESCRIPTION
### Behov / Bakgrunn
Ved sletting av deltakelse der bruker enda ikkje har søkt må vi sette oppgave for å søke ytelse til avbrutt.

### Løsning
Kaller ung-brukerdialog-api sitt endepunkt for å sette oppgave til avbrutt

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
