### PR TITLE
chore: Setter loglevel til WARNING for db-logging

### DIFF
--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -50,6 +50,8 @@
         <appender-ref ref="auditLogger" />
     </logger>
 
+    <logger name="org.hibernate.orm.connections.pooling" level="WARN"/>
+
     <root level="INFO">
         <appender-ref ref="stdout_json"/>
     </root>


### PR DESCRIPTION
### Behov / Bakgrunn
Skrur ned loglevel for Hibernate Connections Pooling

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
