### PR TITLE
TSFF-2761 - Bruker UngdomsprogramOpphørOpphevetHendelse for å oppheve tidligere opphørt ytelse

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -21,7 +21,7 @@
         <logback.logstash.version>9.0</logback.logstash.version>
         <spring-mockk.version>5.0.1</spring-mockk.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <ung-sak.version>7.7.2</ung-sak.version>
+        <ung-sak.version>7.7.5</ung-sak.version>
         <ung-brukerdialog-api.version>1.0.3</ung-brukerdialog-api.version>
 
         <fp-sak.version>2.7.4</fp-sak.version>

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -429,7 +429,7 @@ class UngdomsprogramregisterService(
         eksisterendeDeltakelse.oppdaterPeriode(nyPeriodeUtenSluttdato)
 
         val lagret = deltakelseRepository.save(eksisterendeDeltakelse)
-        sendOpphørOpphevetHendelseTilUngSak(eksisterendeDeltakelse, tidligereOpphørsdato)
+        sendOpphørOpphevetHendelseTilUngSak(lagret, tidligereOpphørsdato)
 
         return lagret.mapToDTO()
     }
@@ -563,16 +563,16 @@ class UngdomsprogramregisterService(
     }
 
 
-    private fun sendOpphørOpphevetHendelseTilUngSak(eksisterende: DeltakelseDAO, tidligereOpphørsdato: LocalDate) {
+    private fun sendOpphørOpphevetHendelseTilUngSak(oppdatert: DeltakelseDAO, tidligereOpphørsdato: LocalDate) {
         logger.info("Henter aktørIder for deltaker")
-        val aktørIder = pdlService.hentAktørIder(eksisterende.deltaker.deltakerIdent)
+        val aktørIder = pdlService.hentAktørIder(oppdatert.deltaker.deltakerIdent)
         val nåværendeAktørId = aktørIder.first { !it.historisk }.ident
 
         logger.info("Sender inn hendelse til ung-sak om at opphøret av deltakelse er opphevet")
 
         val hendelsedato =
-            eksisterende.endretTidspunkt?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
-                ?: eksisterende.opprettetTidspunkt.atZone(ZoneOffset.UTC).toLocalDateTime()
+            oppdatert.endretTidspunkt?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
+                ?: oppdatert.opprettetTidspunkt.atZone(ZoneOffset.UTC).toLocalDateTime()
 
         val hendelseInfo = HendelseInfo.Builder().medOpprettet(hendelsedato)
         aktørIder.forEach {

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -25,6 +25,7 @@ import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramEndretStartdatoHendelse
 import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramFjernDeltakelseHendelse
 import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramForlengetPeriodeHendelse
 import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramOpphørHendelse
+import no.nav.ung.sak.kontrakt.hendelser.UngdomsprogramOpphørOpphevetHendelse
 import no.nav.ung.sak.typer.AktørId
 import no.nav.ung.sak.typer.Periode
 import org.slf4j.LoggerFactory
@@ -423,11 +424,12 @@ class UngdomsprogramregisterService(
         }
 
         logger.info("Sletter sluttdato for deltakelse med id $deltakelseId")
+        val tidligereOpphørsdato = eksisterendeDeltakelse.getTom()!!
         val nyPeriodeUtenSluttdato = Range.closedInfinite(eksisterendeDeltakelse.getFom())
         eksisterendeDeltakelse.oppdaterPeriode(nyPeriodeUtenSluttdato)
 
         val lagret = deltakelseRepository.save(eksisterendeDeltakelse)
-        sendEndretSluttdatoHendelseTilUngSak(lagret)
+        sendOpphørOpphevetHendelseTilUngSak(eksisterendeDeltakelse, tidligereOpphørsdato)
 
         return lagret.mapToDTO()
     }
@@ -552,6 +554,32 @@ class UngdomsprogramregisterService(
         }
 
         val hendelse = UngdomsprogramOpphørHendelse(hendelseInfo.build(), sluttdato)
+        ungSakService.sendInnHendelse(
+            hendelse = HendelseDto(
+                hendelse,
+                AktørId(nåværendeAktørId)
+            )
+        )
+    }
+
+
+    private fun sendOpphørOpphevetHendelseTilUngSak(eksisterende: DeltakelseDAO, tidligereOpphørsdato: LocalDate) {
+        logger.info("Henter aktørIder for deltaker")
+        val aktørIder = pdlService.hentAktørIder(eksisterende.deltaker.deltakerIdent)
+        val nåværendeAktørId = aktørIder.first { !it.historisk }.ident
+
+        logger.info("Sender inn hendelse til ung-sak om at opphøret av deltakelse er opphevet")
+
+        val hendelsedato =
+            eksisterende.endretTidspunkt?.atZone(ZoneOffset.UTC)?.toLocalDateTime()
+                ?: eksisterende.opprettetTidspunkt.atZone(ZoneOffset.UTC).toLocalDateTime()
+
+        val hendelseInfo = HendelseInfo.Builder().medOpprettet(hendelsedato)
+        aktørIder.forEach {
+            hendelseInfo.leggTilAktør(AktørId(it.ident))
+        }
+
+        val hendelse = UngdomsprogramOpphørOpphevetHendelse(hendelseInfo.build(), tidligereOpphørsdato)
         ungSakService.sendInnHendelse(
             hendelse = HendelseDto(
                 hendelse,


### PR DESCRIPTION
### Behov / Bakgrunn

Det må være mulig å endre/fjerne sluttdato i veilederapp (ung-deltakelse-opplyser) når den er satt feil, uten å sende varsel til bruker — bruker har allerede vært i kontakt med Nav i forkant (typisk ved medhold i klage på opphør av ungdomsprogrammet).

Funksjonaliteten i ung-deltakelse-opplyser gjenbruker i dag `UngdomsprogramOpphørHendelse`, noe som blir feil med tanke på flyt og brev. Bakgrunnen er at vi gjenbrukte opphørshendelsen som trigget feil flyt i ung-sak, skapte varsler og feil brev.

### Løsning

Endret `slettSluttdato` til å sende `UngdomsprogramOpphørOpphevetHendelse` til ung-sak i stedet for å gjenbruke opphørs-/endret-sluttdato-hendelsen, slik at riktig flyt og brev trigges når sluttdatoen fjernes.

### Andre endringer

- Oppgradert `ung-sak` fra 7.7.2 til 7.7.5 for å få tilgang til `UngdomsprogramOpphørOpphevetHendelse`.


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
