### PR TITLE
Validerer at sluttdato ikke kan havne etter maksdato ved periodeendring.

### DIFF
--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -342,6 +342,11 @@ class UngdomsprogramregisterService(
             Range.closed(deltakelseDTO.fraOgMed, deltakelseDTO.tilOgMed)
         }
 
+        val tilOgMed = deltakelseDTO.tilOgMed
+        if (tilOgMed != null) {
+            forsikreSluttdatoErInnenforMaksdato(tilOgMed, eksiterende.getFom(), eksiterende.harForlengetPeriode)
+        }
+
         eksiterende.oppdaterPeriode(periode)
         val oppdatert = deltakelseRepository.save(eksiterende)
 

--- a/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
+++ b/app/src/main/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterService.kt
@@ -377,6 +377,9 @@ class UngdomsprogramregisterService(
 
         forsikreGyldigPeriodeVedEndring(sluttdato, endretStartdato)
         forsikrePeriodeErInnenforDeltakersGyldigeAlder(endretStartdato, deltakerPersonalia)
+        if (sluttdato != null) {
+            forsikreSluttdatoErInnenforMaksdato(sluttdato, endretStartdato, eksisterendeDeltakelse.harForlengetPeriode)
+        }
 
         val nyPeriodeMedEndretStartdato: Range<LocalDate> = if (sluttdato != null) {
             Range.closed(endretStartdato, sluttdato)
@@ -402,6 +405,7 @@ class UngdomsprogramregisterService(
         val endretSluttdato = endrePeriodeDatoDTO.dato
         forsikreGyldigPeriodeVedEndring(endretSluttdato, deltakelseFraOgMedDato)
         forsikrePeriodeErInnenforDeltakersGyldigeAlder(endretSluttdato, deltakerPersonalia)
+        forsikreSluttdatoErInnenforMaksdato(endretSluttdato, deltakelseFraOgMedDato, eksisterendeDeltakelse.harForlengetPeriode)
 
 
         val nyPeriodeMedEndretSluttdato = Range.closed(eksisterendeDeltakelse.getFom(), endrePeriodeDatoDTO.dato)
@@ -682,6 +686,23 @@ class UngdomsprogramregisterService(
                 null
             )
         }
+
+    private fun forsikreSluttdatoErInnenforMaksdato(
+        sluttdato: LocalDate,
+        startdato: LocalDate,
+        harForlengetPeriode: Boolean,
+    ) {
+        val maksDato = ForlengetPeriodeBeregner.beregn(startdato, harForlengetPeriode).tilOgMed
+        if (sluttdato > maksDato) {
+            throw ErrorResponseException(
+                HttpStatus.BAD_REQUEST,
+                ProblemDetail.forStatus(HttpStatus.BAD_REQUEST).also {
+                    it.detail = "Sluttdato=$sluttdato kan ikke være etter maksdato=$maksDato"
+                },
+                null
+            )
+        }
+    }
 
     private fun forsikreGyldigPeriodeVedEndring(sluttdato: LocalDate?, startdato: LocalDate) {
         if (sluttdato != null && sluttdato < startdato) {

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -619,5 +619,61 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         }
     }
 
+    @Test
+    fun `endreSluttdato til etter maksdato gir valideringsfeil`() {
+        every { pdlService.hentAktørIder(any()) } returns listOf(
+            IdentInformasjon("321", false, IdentGruppe.AKTORID),
+            IdentInformasjon("451", true, IdentGruppe.AKTORID)
+        )
+
+        val startdato = LocalDate.parse("2024-10-07")
+        val maksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed
+        val innmelding = ungdomsprogramregisterService.leggTilIProgram(
+            DeltakelseDTO(
+                deltaker = DeltakerDTO(deltakerIdent = FødselsnummerGenerator.neste()),
+                fraOgMed = startdato,
+                periodeMaksDato = maksDato,
+            )
+        )
+
+        assertThrows<ErrorResponseException> {
+            ungdomsprogramregisterService.endreSluttdato(innmelding.id!!, mockEndrePeriodeDTO(maksDato.plusDays(1)))
+        }.also {
+            assertThat(it.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(it.body.detail).contains("kan ikke være etter maksdato")
+        }
+    }
+
+    @Test
+    fun `endreStartdato bakover slik at eksisterende sluttdato overstiger ny maksdato gir valideringsfeil`() {
+        every { pdlService.hentAktørIder(any()) } returns listOf(
+            IdentInformasjon("321", false, IdentGruppe.AKTORID),
+            IdentInformasjon("451", true, IdentGruppe.AKTORID)
+        )
+
+        val startdato = LocalDate.parse("2024-10-07") // mandag
+        val sluttdato = LocalDate.parse("2025-06-01") // innenfor maksdato fra startdato
+        val innmelding = ungdomsprogramregisterService.leggTilIProgram(
+            DeltakelseDTO(
+                deltaker = DeltakerDTO(deltakerIdent = FødselsnummerGenerator.neste()),
+                fraOgMed = startdato,
+                periodeMaksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed,
+            )
+        )
+        ungdomsprogramregisterService.avsluttDeltakelse(
+            innmelding.id!!,
+            DeltakelseDTO(deltaker = innmelding.deltaker, fraOgMed = startdato, tilOgMed = sluttdato, periodeMaksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed)
+        )
+
+        // Ny startdato 2024-01-08: maksdato ≈ 2025-01-06, som er før sluttdato 2025-06-01
+        val nyStartdato = LocalDate.parse("2024-01-08") // mandag
+        assertThrows<ErrorResponseException> {
+            ungdomsprogramregisterService.endreStartdato(innmelding.id!!, mockEndrePeriodeDTO(nyStartdato))
+        }.also {
+            assertThat(it.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(it.body.detail).contains("kan ikke være etter maksdato")
+        }
+    }
+
     private fun mockEndrePeriodeDTO(dato: LocalDate) = EndrePeriodeDatoDTO(dato = dato)
 }

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/domene/register/UngdomsprogramregisterServiceTest.kt
@@ -675,5 +675,33 @@ class UngdomsprogramregisterServiceTest : AbstractIntegrationTest() {
         }
     }
 
+    @Test
+    fun `avsluttDeltakelse med sluttdato etter maksdato gir valideringsfeil`() {
+        val startdato = LocalDate.parse("2024-10-07")
+        val maksDato = ForlengetPeriodeBeregner.beregn(startdato).tilOgMed
+        val innmelding = ungdomsprogramregisterService.leggTilIProgram(
+            DeltakelseDTO(
+                deltaker = DeltakerDTO(deltakerIdent = FødselsnummerGenerator.neste()),
+                fraOgMed = startdato,
+                periodeMaksDato = maksDato,
+            )
+        )
+
+        assertThrows<ErrorResponseException> {
+            ungdomsprogramregisterService.avsluttDeltakelse(
+                innmelding.id!!,
+                DeltakelseDTO(
+                    deltaker = innmelding.deltaker,
+                    fraOgMed = startdato,
+                    tilOgMed = maksDato.plusDays(1),
+                    periodeMaksDato = maksDato,
+                )
+            )
+        }.also {
+            assertThat(it.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+            assertThat(it.body.detail).contains("kan ikke være etter maksdato")
+        }
+    }
+
     private fun mockEndrePeriodeDTO(dato: LocalDate) = EndrePeriodeDatoDTO(dato = dato)
 }


### PR DESCRIPTION
### Behov / Bakgrunn

Sluttdato hadde ingen validering mot `periodeMaksDato`. Det var mulig å sette sluttdato etter maksdato via tre inngangspunkter:

- `endreSluttdato` — ingen sjekk mot maksdato
- `endreStartdato` — ingen sjekk på om eksisterende sluttdato overstiger ny maksdato ved bakoverflytting av startdato
- `avsluttDeltakelse` — ingen sjekk mot maksdato ved utmelding

### Løsning

Ny privat hjelpefunksjon `forsikreSluttdatoErInnenforMaksdato` i `UngdomsprogramregisterService` som kaster HTTP 400 hvis sluttdato > maksdato.

Funksjonen kalles fra:
- `avsluttDeltakelse` — validerer `tilOgMed` mot maksdato fra lagret startdato (kun når `tilOgMed != null`)
- `endreSluttdato` — validerer ny sluttdato mot gjeldende maksdato
- `endreStartdato` — validerer eksisterende sluttdato mot ny (potensielt tidligere) maksdato

### Andre endringer

Tre nye integrasjonstester i `UngdomsprogramregisterServiceTest`:
- `avsluttDeltakelse med sluttdato etter maksdato gir valideringsfeil`
- `endreSluttdato til etter maksdato gir valideringsfeil`
- `endreStartdato bakover slik at eksisterende sluttdato overstiger ny maksdato gir valideringsfeil`

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
