### PR TITLE
Tester NomApiService og PdlService med WireMock stubs.

### DIFF
--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/nom/api/NomApiServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/nom/api/NomApiServiceTest.kt
@@ -1,0 +1,180 @@
+package no.nav.ung.deltakelseopplyser.integration.nom.api
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.ninjasquad.springmockk.MockkBean
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import no.nav.ung.deltakelseopplyser.statistikk.bigquery.BigQueryTestConfiguration
+import no.nav.ung.deltakelseopplyser.utils.TokenTestUtils.mockContext
+import no.nav.ung.deltakelseopplyser.wiremock.AutoConfigureWireMock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.LocalDate
+
+@AutoConfigureWireMock
+@EnableMockOAuth2Server
+@ExtendWith(SpringExtension::class)
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "topic.listener.ung-soknad.bryter=false",
+        "topic.listener.ung-oppgavebekreftelse.bryter=false",
+        "topic.listener.ung-rapportert-inntekt.bryter=false",
+        "topic.listener.ung-vedtakhendelse.bryter=false",
+    ]
+)
+@Import(BigQueryTestConfiguration::class)
+class NomApiServiceTest {
+
+    @Autowired
+    private lateinit var nomApiService: NomApiService
+
+    @Autowired
+    private lateinit var wireMockServer: WireMockServer
+
+    @MockkBean
+    private lateinit var springTokenValidationContextHolder: SpringTokenValidationContextHolder
+
+    private companion object {
+        const val NOM_GRAPHQL_PATH = "/nom-api-mock/graphql"
+    }
+
+    @BeforeEach
+    fun setUp() {
+        springTokenValidationContextHolder.mockContext()
+    }
+
+    @Test
+    fun `hentResursserMedAlleTilknytninger returnerer ressurs med org-tilknytning ved OK-respons`() {
+        val navIdent = "A123456"
+        val enhetId = "enhet-uuid-1"
+        stubNomPost(
+            // language=json
+            """
+            {
+              "data": {
+                "ressurser": [
+                  {
+                    "ressurs": {
+                      "navident": "$navIdent",
+                      "orgTilknytning": [
+                        {
+                          "gyldigFom": "2020-01-01",
+                          "gyldigTom": null,
+                          "orgEnhet": {
+                            "id": "$enhetId",
+                            "remedyEnhetId": "remedy-uuid-1",
+                            "navn": "NAV Oslo",
+                            "gyldigFom": "2020-01-01",
+                            "gyldigTom": null,
+                            "orgEnhetsType": "NAV_KONTOR",
+                            "agressoOrgenhetType": null
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+            """.trimIndent()
+        )
+
+        val resultat = nomApiService.hentResursserMedAlleTilknytninger(setOf(navIdent))
+
+        assertThat(resultat).hasSize(1)
+        val ressurs = resultat.first()
+        assertThat(ressurs.navIdent).isEqualTo(navIdent)
+        assertThat(ressurs.orgTilknytninger).hasSize(1)
+        val tilknytning = ressurs.orgTilknytninger.first()
+        assertThat(tilknytning.gyldigFom).isEqualTo(LocalDate.of(2020, 1, 1))
+        assertThat(tilknytning.gyldigTom).isNull()
+        assertThat(tilknytning.orgEnhet.id).isEqualTo(enhetId)
+        assertThat(tilknytning.orgEnhet.navn).isEqualTo("NAV Oslo")
+    }
+
+    @Test
+    fun `hentResursserMedAlleTilknytninger kaster IllegalStateException ved feilrespons fra NOM`() {
+        stubNomPost(
+            // language=json
+            """
+            {
+              "errors": [{"message": "Fant ikke ressurs", "locations": [], "path": ["ressurser"], "extensions": {"code": "not_found"}}],
+              "data": null
+            }
+            """.trimIndent()
+        )
+
+        assertThrows<IllegalStateException> {
+            nomApiService.hentResursserMedAlleTilknytninger(setOf("A123456"))
+        }
+    }
+
+    @Test
+    fun `hentResursserMedAlleTilknytninger returnerer delmengde når færre ressurser enn forespurte navIdenter`() {
+        val navIdent1 = "A111111"
+        val navIdent2 = "A222222"
+        stubNomPost(
+            // language=json
+            """
+            {
+              "data": {
+                "ressurser": [
+                  {
+                    "ressurs": {
+                      "navident": "$navIdent1",
+                      "orgTilknytning": [
+                        {
+                          "gyldigFom": "2021-06-01",
+                          "gyldigTom": "2023-12-31",
+                          "orgEnhet": {
+                            "id": "enhet-uuid-2",
+                            "remedyEnhetId": null,
+                            "navn": "NAV Bergen",
+                            "gyldigFom": "2021-06-01",
+                            "gyldigTom": "2023-12-31",
+                            "orgEnhetsType": "NAV_KONTOR",
+                            "agressoOrgenhetType": null
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+            """.trimIndent()
+        )
+
+        val resultat = nomApiService.hentResursserMedAlleTilknytninger(setOf(navIdent1, navIdent2))
+
+        assertThat(resultat).hasSize(1)
+        assertThat(resultat.first().navIdent).isEqualTo(navIdent1)
+        val tilknytning = resultat.first().orgTilknytninger.first()
+        assertThat(tilknytning.gyldigFom).isEqualTo(LocalDate.of(2021, 6, 1))
+        assertThat(tilknytning.gyldigTom).isEqualTo(LocalDate.of(2023, 12, 31))
+    }
+
+    private fun stubNomPost(responseBody: String) {
+        wireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo(NOM_GRAPHQL_PATH))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBody)
+                )
+        )
+    }
+}

--- a/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/pdl/api/PdlServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/ung/deltakelseopplyser/integration/pdl/api/PdlServiceTest.kt
@@ -1,0 +1,191 @@
+package no.nav.ung.deltakelseopplyser.integration.pdl.api
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.ninjasquad.springmockk.MockkBean
+import no.nav.pdl.generated.enums.IdentGruppe
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import no.nav.ung.deltakelseopplyser.statistikk.bigquery.BigQueryTestConfiguration
+import no.nav.ung.deltakelseopplyser.utils.FødselsnummerGenerator
+import no.nav.ung.deltakelseopplyser.utils.TokenTestUtils.mockContext
+import no.nav.ung.deltakelseopplyser.wiremock.AutoConfigureWireMock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@AutoConfigureWireMock
+@EnableMockOAuth2Server
+@ExtendWith(SpringExtension::class)
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "topic.listener.ung-soknad.bryter=false",
+        "topic.listener.ung-oppgavebekreftelse.bryter=false",
+        "topic.listener.ung-rapportert-inntekt.bryter=false",
+        "topic.listener.ung-vedtakhendelse.bryter=false",
+    ]
+)
+@Import(BigQueryTestConfiguration::class)
+class PdlServiceTest {
+
+    @Autowired
+    private lateinit var pdlService: PdlService
+
+    @Autowired
+    private lateinit var wireMockServer: WireMockServer
+
+    @MockkBean
+    private lateinit var springTokenValidationContextHolder: SpringTokenValidationContextHolder
+
+    private companion object {
+        const val PDL_GRAPHQL_PATH = "/pdl-api-mock/graphql"
+    }
+
+    @BeforeEach
+    fun setUp() {
+        springTokenValidationContextHolder.mockContext()
+    }
+
+    @Test
+    fun `hentPerson returnerer person ved OK-respons`() {
+        val fnr = FødselsnummerGenerator.neste()
+        stubPdlPost(
+            // language=json
+            """
+            {
+              "data": {
+                "hentPerson": {
+                  "folkeregisteridentifikator": [{"identifikasjonsnummer": "$fnr"}],
+                  "navn": [{"fornavn": "Ola", "mellomnavn": null, "etternavn": "Nordmann"}],
+                  "foedselsdato": [{"foedselsdato": "2000-01-01", "foedselsaar": 2000}]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val person = pdlService.hentPerson(fnr)
+
+        assertThat(person.folkeregisteridentifikator).hasSize(1)
+        assertThat(person.folkeregisteridentifikator.first().identifikasjonsnummer).isEqualTo(fnr)
+        assertThat(person.navn.first().fornavn).isEqualTo("Ola")
+        assertThat(person.navn.first().etternavn).isEqualTo("Nordmann")
+        assertThat(person.foedselsdato.first().foedselsdato).isEqualTo("2000-01-01")
+    }
+
+    @Test
+    fun `hentPerson kaster IllegalStateException ved feilrespons fra PDL`() {
+        stubPdlPost(
+            // language=json
+            """
+            {
+              "errors": [{"message": "Fant ikke person", "locations": [], "path": ["hentPerson"], "extensions": {"code": "not_found"}}],
+              "data": null
+            }
+            """.trimIndent()
+        )
+
+        assertThrows<IllegalStateException> { pdlService.hentPerson("12345678901") }
+    }
+
+    @Test
+    fun `hentIdenter returnerer identliste med alle identer ved OK-respons`() {
+        val fnr = FødselsnummerGenerator.neste()
+        val aktørId = "9876543210123"
+        stubPdlPost(
+            // language=json
+            """
+            {
+              "data": {
+                "hentIdenter": {
+                  "identer": [
+                    {"ident": "$fnr", "historisk": false, "gruppe": "FOLKEREGISTERIDENT"},
+                    {"ident": "$aktørId", "historisk": false, "gruppe": "AKTORID"}
+                  ]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val identliste = pdlService.hentIdenter(fnr)
+
+        assertThat(identliste.identer).hasSize(2)
+        assertThat(identliste.identer.map { it.ident }).containsExactlyInAnyOrder(fnr, aktørId)
+    }
+
+    @Test
+    fun `hentFolkeregisteridenter returnerer kun FOLKEREGISTERIDENT-innslag`() {
+        val fnr = FødselsnummerGenerator.neste()
+        stubPdlPost(
+            // language=json
+            """
+            {
+              "data": {
+                "hentIdenter": {
+                  "identer": [
+                    {"ident": "$fnr", "historisk": false, "gruppe": "FOLKEREGISTERIDENT"},
+                    {"ident": "9876543210123", "historisk": false, "gruppe": "AKTORID"}
+                  ]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val folkeregisteridenter = pdlService.hentFolkeregisteridenter(fnr)
+
+        assertThat(folkeregisteridenter).hasSize(1)
+        assertThat(folkeregisteridenter.first().gruppe).isEqualTo(IdentGruppe.FOLKEREGISTERIDENT)
+        assertThat(folkeregisteridenter.first().ident).isEqualTo(fnr)
+    }
+
+    @Test
+    fun `hentAktørIder returnerer kun AKTORID-innslag`() {
+        val fnr = FødselsnummerGenerator.neste()
+        val aktørId = "9876543210123"
+        stubPdlPost(
+            // language=json
+            """
+            {
+              "data": {
+                "hentIdenter": {
+                  "identer": [
+                    {"ident": "$fnr", "historisk": false, "gruppe": "FOLKEREGISTERIDENT"},
+                    {"ident": "$aktørId", "historisk": false, "gruppe": "AKTORID"}
+                  ]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val aktørIder = pdlService.hentAktørIder(fnr)
+
+        assertThat(aktørIder).hasSize(1)
+        assertThat(aktørIder.first().gruppe).isEqualTo(IdentGruppe.AKTORID)
+        assertThat(aktørIder.first().ident).isEqualTo(aktørId)
+    }
+
+    private fun stubPdlPost(responseBody: String) {
+        wireMockServer.stubFor(
+            WireMock.post(WireMock.urlPathEqualTo(PDL_GRAPHQL_PATH))
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBody)
+                )
+        )
+    }
+}


### PR DESCRIPTION
### Behov / Bakgrunn

Manglet tester for integrasjonslaget mot NOM og PDL, noe som gjorde det vanskelig å verifisere korrekt håndtering av API-responser og feilsituasjoner ved pakkeoppdatering.

### Løsning

Lagt til WireMock-baserte integrasjonstester for:
- `NomApiService`: henting av ressurser med org-tilknytninger, inkludert feilhåndtering og delmengde-scenarioer
- `PdlService`: henting av person, identer, folkeregisteridenter og aktørIder, inkludert feilhåndtering

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
